### PR TITLE
chore: Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,60 @@
+name: '🐞 Bug report'
+description: Create a report to help us improve vue-devui
+labels: ['pending triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the following carefully in order to better fix the problem.
+  - type: input
+    id: devui-version
+    attributes:
+      label: Version
+      description: |
+        ### **Check if the issue is reproducible with the latest stable version.**
+        You can use the command `npm ls vue-devui` to view it
+      placeholder: latest
+    validations:
+      required: true
+  - type: input
+    id: vue-version
+    attributes:
+      label: Vue Version
+      placeholder: latest
+    validations:
+      required: true
+  - type: textarea
+    id: minimal-repo
+    attributes:
+      label: Link to minimal reproduction
+      description: |
+        **Provide a streamlined CodePen / CodeSandbox or GitHub repository link as much as possible. Please don't fill in a link randomly, it will only close your issue directly.**
+      placeholder: Please Input
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Step to reproduce
+      description: |
+        **After the replay is turned on, what actions do we need to perform to make the bug appear? Simple and clear steps can help us locate the problem more quickly. Please clearly describe the steps of reproducing the issue. Issues without clear reproducing steps will not be repaired. If the issue marked with 'need reproduction' does not provide relevant steps within 7 days, it will be closed directly.**
+      placeholder: Please Input
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is expected
+      placeholder: Please Input
+  - type: textarea
+    id: actually
+    attributes:
+      label: What is actually happening
+      placeholder: Please Input
+  - type: textarea
+    id: additional-comments
+    attributes:
+      label: Any additional comments (optional)
+      description: |
+        **Some background / context of how you ran into this bug.**
+      placeholder: Please Input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,22 @@
+name: '💡 Feature Request'
+description: Propose new features to vue-devui to improve it.
+labels: ['pending triage']
+body:
+  - type: textarea
+    id: feature-solve
+    attributes:
+      label: What problem does this feature solve
+      description: |
+        Explain your use case, context, and rationale behind this feature request. More importantly, what is the end user experience you are trying to build that led to the need for this feature?
+      placeholder: Please Input
+    validations:
+      required: true
+  - type: textarea
+    id: feature-api
+    attributes:
+      label: What does the proposed API look like
+      description: |
+        Describe how you propose to solve the problem and provide code samples of how the API would work once implemented. Note that you can use Markdown to format your code blocks.
+      placeholder: Please Input
+    validations:
+      required: true


### PR DESCRIPTION
Added `Bug report` and `Feature Request` issue templates
In my warehouse, I implemented a version of it
[A preview of the effect](https://github.com/whylost/vue-devui-actiontest/issues/new/choose)