### PR TITLE
refactor(Tree): 重构树组件高亮显示代码

### DIFF
--- a/packages/devui-vue/devui/tree/src/composables/use-highlight.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-highlight.ts
@@ -1,37 +1,44 @@
-import { ref, Ref } from 'vue'
+import { ref } from 'vue'
 
-interface TypeHighlightClass {
-  [key: string]: 'active' | '' | 'devui-tree_isDisabledNode'
-}
+type TypeHighlightClass = HIGHLIGHT_CLASS
+
 type TypeUseHighlightNode = () => {
-  nodeClassNameReflect: Ref<TypeHighlightClass>
-  handleClickOnNode: (index: string) => void
-  handleInitNodeClassNameReflect: (isDisabled: boolean, ...keys: Array<string>) => string
+  highLightClick: (index: string) => void
+  initHighLightNode: (isDisabled: boolean, nodeId: string) => void,
+  getHighLightClass: (nodeId: string) => TypeHighlightClass
 }
 
-const HIGHLIGHT_CLASS = 'active'
-const IS_DISABLED_FLAG = 'devui-tree_isDisabledNode'
+enum HIGHLIGHT_CLASS {
+  ACTIVE = 'active',
+  DISABLED = 'devui-tree_isDisabledNode',
+  EMPTY = ''
+}
+
+const disabledNodeIdSet = new Set<string>()
+
 const useHighlightNode: TypeUseHighlightNode = () => {
-  const nodeClassNameReflectRef = ref<TypeHighlightClass>({})
-  const prevActiveNodeKey = ref<string>('')
-  const handleInit = (isDisabled = false, ...keys) => {
-    const key = keys.join('-')
-    nodeClassNameReflectRef.value[key] = isDisabled
-      ? IS_DISABLED_FLAG
-      : nodeClassNameReflectRef.value[key] || ''
-    return key
+
+  const currentHighLightNodeId = ref<string>('')
+
+  const initHighLightNode = (isDisabled = false, nodeId: string): void => {
+    if (isDisabled) disabledNodeIdSet.add(nodeId)
   }
-  const handleClick = (key) => {
-    if (nodeClassNameReflectRef.value[key] === IS_DISABLED_FLAG) return
-    if (prevActiveNodeKey.value === key) return
-    if (prevActiveNodeKey.value) nodeClassNameReflectRef.value[prevActiveNodeKey.value] = ''
-    nodeClassNameReflectRef.value[key] = HIGHLIGHT_CLASS
-    prevActiveNodeKey.value = key
+
+  const highLightClick = (nodeId: string): void => {
+    if (disabledNodeIdSet.has(nodeId)) return
+    currentHighLightNodeId.value = nodeId
   }
+
+  const getHighLightClass = ((nodeId: string): TypeHighlightClass => {
+    if (disabledNodeIdSet.has(nodeId)) return HIGHLIGHT_CLASS.DISABLED
+    if (nodeId === currentHighLightNodeId.value) return HIGHLIGHT_CLASS.ACTIVE
+    return HIGHLIGHT_CLASS.EMPTY
+  })
+
   return {
-    nodeClassNameReflect: nodeClassNameReflectRef,
-    handleClickOnNode: handleClick,
-    handleInitNodeClassNameReflect: handleInit
+    highLightClick,
+    initHighLightNode,
+    getHighLightClass
   }
 }
 export default useHighlightNode

--- a/packages/devui-vue/devui/tree/src/tree.tsx
+++ b/packages/devui-vue/devui/tree/src/tree.tsx
@@ -24,7 +24,7 @@ export default defineComponent({
     const { data, checkable, checkableRelation: cbr } = toRefs(reactive({ ...props, data: preCheckTree(props.data) }))
     const { mergeData } = useMergeNode(data.value)
     const { openedData, toggle } = useToggle(mergeData)
-    const { nodeClassNameReflect, handleInitNodeClassNameReflect, handleClickOnNode } = useHighlightNode()
+    const { getHighLightClass, initHighLightNode, highLightClick } = useHighlightNode()
     const { lazyNodesReflect, handleInitLazyNodeReflect, getLazyData } = useLazy()
     const { selected, onNodeClick } = useChecked(cbr, ctx, data.value)
     const { editStatusReflect, operateIconReflect, handleReflectIdToIcon } = useOperate(data)
@@ -65,7 +65,7 @@ export default defineComponent({
           },
         }
       )
-      handleInitNodeClassNameReflect(disabled, id)
+      initHighLightNode(disabled, id)
       handleInitLazyNodeReflect(item, {
         id,
         onGetNodeData: async () => {
@@ -116,8 +116,8 @@ export default defineComponent({
           style={{ paddingLeft: `${24 * (level - 1)}px` }}
         >
           <div
-            class={`devui-tree-node__content ${nodeClassNameReflect.value[id]}`}
-            onClick={() => handleClickOnNode(id)}
+            class={`devui-tree-node__content ${getHighLightClass(id)}`}
+            onClick={() => highLightClick(id)}
           >
             <div class="devui-tree-node__content--value-wrapper">
               { renderFoldIcon(item) }


### PR DESCRIPTION
修改内容：
1. 修改use-highlight.ts文件中变量命名，使其更易读
2. 简化use-highlight.ts代码逻辑，定义currentHighLightNodeId来保存当前高亮节点id，变化时重新渲染树组件
3. 由于use-highlight.ts中导出变量名变化，Tree.tsx中相应地方需要修改