### PR TITLE
docs: 优化文档中表格的样式

### DIFF
--- a/packages/devui-vue/docs/.vitepress/devui-theme/styles/layout.scss
+++ b/packages/devui-vue/docs/.vitepress/devui-theme/styles/layout.scss
@@ -173,7 +173,8 @@ li > ol {
 }
 
 table {
-  display: block;
+  display: table;
+  width: 100%;
   border-collapse: collapse;
   margin: 1rem 0;
   overflow-x: auto;


### PR DESCRIPTION
Update:
1. 将表格宽度改成`100%`