### PR TITLE
chore: 修改.prerrierrc配置统一加上句尾分号

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "htmlWhitespaceSensitivity": "ignore",
   "jsxSingleQuote": true,
   "printWidth": 100,
-  "semi": false,
+  "semi": true,
   "useTabs": false,
   "trailingComma": "none",
   "singleQuote": true,


### PR DESCRIPTION
Update:
1. 将`.prerrierrc`配置的`semi `改成`true`，解决与`eslintrc.js`配置冲突的问题 #29 