### PR TITLE
fix: 密码框切换明暗文切换后, 右侧icon图标不显示(#194)

### DIFF
--- a/packages/devui-vue/devui/input/src/input.tsx
+++ b/packages/devui-vue/devui/input/src/input.tsx
@@ -41,7 +41,7 @@ export default defineComponent({
     watch(
       () => props.modelValue,
       (value) => {
-        value && value.length > 0 && showPreviewIcon.value
+        value && value.length > 0
           ? (showPwdIcon.value = true)
           : (showPwdIcon.value = false)
       }


### PR DESCRIPTION
修复bug: 密码框切换明暗文切换后, 右侧icon图标不显示 （#194）