### PR TITLE
fix(eslint): off no-undef

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,5 +44,13 @@ module.exports = {
     ],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error']
-  }
+  },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        'no-undef': 'off'
+      }
+    }
+  ]
 }


### PR DESCRIPTION
在 ts 或者 tsx 有如下 eslint 报错
```
'JSX' is not defined.eslint[no-undef]
```
