### PR TITLE
build: add script cli

### DIFF
--- a/packages/devui-vue/dc.config.ts
+++ b/packages/devui-vue/dc.config.ts
@@ -2,7 +2,7 @@ import { defineCliConfig } from 'devui-cli';
 
 export default defineCliConfig({
   componentRootDir: './devui',
-  libClassPrefix: 'd',
+  libClassPrefix: 'devui',
   libEntryFileName: 'vue-devui',
   libEntryRootDir: './devui',
   libPrefix: 'D',

--- a/packages/devui-vue/package.json
+++ b/packages/devui-vue/package.json
@@ -35,7 +35,8 @@
     "copy": "cp package.json build && cp ../../README.md build && cp devui/theme/theme.scss build/theme",
     "cli:create": "node ./devui-cli/index.js create -t component",
     "predev": "node ./devui-cli/index.js create -t vue-devui --ignore-parse-error",
-    "prebuild": "node ./devui-cli/index.js create -t vue-devui --ignore-parse-error"
+    "prebuild": "node ./devui-cli/index.js create -t vue-devui --ignore-parse-error",
+    "cli": "devui"
   },
   "dependencies": {
     "@devui-design/icons": "^1.3.0",
@@ -74,6 +75,7 @@
     "babel-jest": "^27.0.2",
     "chalk": "^4.1.2",
     "commander": "^8.1.0",
+    "devui-cli": "workspace:^0.0.2",
     "inquirer": "^8.1.2",
     "jest": "^27.0.4",
     "ora": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,7 @@ importers:
       babel-jest: ^27.0.2
       chalk: ^4.1.2
       commander: ^8.1.0
+      devui-cli: workspace:^0.0.2
       devui-theme: workspace:^0.0.1
       fs-extra: ^10.0.0
       inquirer: ^8.1.2
@@ -174,6 +175,7 @@ importers:
       babel-jest: 27.5.1
       chalk: 4.1.2
       commander: 8.3.0
+      devui-cli: link:../devui-cli
       inquirer: 8.2.0
       jest: 27.5.1
       ora: 5.4.1


### PR DESCRIPTION
增加脚本命令`cli`，该命令可使用`devui-cli`的能力创建组件模板和入口文件。

使用方式：
```shell
pnpm cli --filter vue-devui
```