### PR TITLE
fix: 修复docs通用栏目button按钮 左按钮右按钮示例代码

### DIFF
--- a/packages/devui-vue/docs/components/button/index.md
+++ b/packages/devui-vue/docs/components/button/index.md
@@ -34,8 +34,8 @@
 :::demo
 ```vue
 <template>
-  <d-button variant="primary" bsPosition="left">Left</d-button>
-  <d-button variant="common" bsPosition="right">Right</d-button>
+  <d-button variant="primary" position="left" style="margin-right: 8px">Left</d-button>
+  <d-button variant="common" position="right">Right</d-button>
 </template>
 ```
 :::


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/43134418/155693181-c2d953c8-bb76-4992-9000-bbe08540b471.png)


After change:
![image](https://user-images.githubusercontent.com/43134418/155692939-90fb3bc0-be3d-43d4-8277-7e9bce2f3fb7.png)
