### PR TITLE
fix: fix build error caused by lodash-es

### DIFF
--- a/packages/devui-vue/devui/drawer/src/drawer-service.tsx
+++ b/packages/devui-vue/devui/drawer/src/drawer-service.tsx
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import { DrawerProps } from './drawer-types'
 
 import DDrawer from './drawer'
-import {  omit } from 'lodash-es'
+import { omit } from 'lodash'
 
 interface drawerInstance {
   hide(): void


### PR DESCRIPTION
Update:
1. `lodash-es` -> `lodash`，修复`pnpm build`构建错误

```
✖ rendering pages...
build error:
 Error [ERR_REQUIRE_ESM]: require() of ES Module vue-devui\node_modules\.pnpm\lodash-es@4.17.21\node_modules\lodash-es\lodash.js from vue-devui\node_modules\.pnpm\vitepress@0.20.1_sass@1.49.8\node_modules\vitepress\dist\client\app\temp\app.js not supported.
Instead change the require of lodash.js in vue-devui\node_modules\.pnpm\vitepress@0.20.1_sass@1.49.8\node_modules\vitepress\dist\client\app\temp\app.js to a dynamic import() which is available in all CommonJS modules.
```