### PR TITLE
fix(progress): fix progress import error

### DIFF
--- a/packages/devui-vue/devui/progress/index.ts
+++ b/packages/devui-vue/devui/progress/index.ts
@@ -1,5 +1,5 @@
 import type { App } from 'vue'
-import { Progress } from './src/progress'
+import Progress from './src/progress'
 
 Progress.install = function(app: App) {
   app.component(Progress.name, Progress)


### PR DESCRIPTION
Update:
1. `import { Progress } from './src/progress'` -> `import Progress from './src/progress'`，解决`pnpm build`报错问题

```
vitepress v0.20.1
- building client + server bundles...
Error when using sourcemap for reporting an error: Can't resolve original location of error.
'Progress' is not exported by devui/progress/src/progress.tsx, imported by devui/progress/index.ts
file: /home/runner/work/vue-devui/vue-devui/packages/devui-vue/devui/progress/index.ts:1:9
1: import { Progress } from "./src/progress";
            ^
2: Progress.install = function(app) {
3:   app.component(Progress.name, Progress);
✖ building client + server bundles...
build error:
 Error: 'Progress' is not exported by devui/progress/src/progress.tsx, imported by devui/progress/index.ts
```