### PR TITLE
test(tree): 完善tree组件基本功能的单元测试

### DIFF
--- a/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree-data.ts
+++ b/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree-data.ts
@@ -1,6 +1,6 @@
-import { ref } from 'vue';
+import type { TreeData } from '../..';
 
-export const basicData = ref([
+export const basicTreeData: TreeData = [
   {
     label: 'Parent node 1',
     open: true,
@@ -26,4 +26,4 @@ export const basicData = ref([
   {
     label: 'Leaf node 2',
   }
-]);
+];

--- a/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
@@ -1,7 +1,7 @@
-import { ComponentPublicInstance, nextTick } from 'vue';
+import { ComponentPublicInstance } from 'vue';
 import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
 import { Tree } from '../../';
-import { basicData } from './basic-data';
+import { basicTreeData } from './basic-tree-data';
 
 describe('Basic tree should include rendering of nested nodes and responses to hover, click and expand/collapse events.', () => {
   let wrapper: VueWrapper<ComponentPublicInstance>;
@@ -11,7 +11,7 @@ describe('Basic tree should include rendering of nested nodes and responses to h
     wrapper = mount({
       setup() {
         return () => {
-          return <Tree data={basicData.value} />;
+          return <Tree data={basicTreeData} />;
         };
       },
     });
@@ -68,12 +68,10 @@ describe('Basic tree should include rendering of nested nodes and responses to h
 
     // 点击之后，节点收起
     await childNodes[0].get('.devui-tree-node__folder').trigger('click');
-    await nextTick();
     expect(childNodes[0].classes()).not.toContain('devui-tree-node__open');
 
     // 再次点击，节点展开
     await childNodes[0].get('.devui-tree-node__folder').trigger('click');
-    await nextTick();
     expect(childNodes[0].classes()).toContain('devui-tree-node__open');
   });
 

--- a/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
@@ -5,8 +5,7 @@ import { basicData } from './basic-data';
 
 describe('Basic tree should include rendering of nested nodes and responses to hover, click and expand/collapse events.', () => {
   let wrapper: VueWrapper<ComponentPublicInstance>;
-  let firstNode: Omit<DOMWrapper<Element>, 'exists'>;
-  let lastNode: Omit<DOMWrapper<Element>, 'exists'>;
+  let childNodes: DOMWrapper<Element>[];
 
   beforeAll(() => {
     wrapper = mount({
@@ -17,8 +16,7 @@ describe('Basic tree should include rendering of nested nodes and responses to h
       },
     });
 
-    firstNode = wrapper.get('.devui-tree-node:first-child');
-    lastNode = wrapper.get('.devui-tree-node:last-child');
+    childNodes = wrapper.findAll('.devui-tree-node');
   });
 
   afterAll(() => {
@@ -26,46 +24,60 @@ describe('Basic tree should include rendering of nested nodes and responses to h
   });
 
   it('Should render tree container correctly.', () => {
-    expect(wrapper.classes()).toContain('devui-tree');
+    expect(wrapper.find('.devui-tree').exists()).toBe(true);
   });
 
   it('Should render correct number of child nodes.', () => {
-    expect(wrapper.element.childElementCount).toBe(5);
+    expect(childNodes).toHaveLength(5);
   });
 
   it('Should render correct node content.', () => {
-    expect(firstNode.text()).toBe('Parent node 1');
-    expect(lastNode.text()).toBe('Leaf node 2');
+    expect(childNodes[0].text()).toBe('Parent node 1');
+    expect(childNodes[childNodes.length - 1].text()).toBe('Leaf node 2');
   });
 
   it('Should render the style of child node correctly.', () => {
-    const childNodeParent = wrapper.get('.devui-tree-node:nth-child(2)');
-    const childNodeLeaf = wrapper.get('.devui-tree-node:nth-child(3)');
-
-    expect(childNodeParent.attributes('style').indexOf('padding-left: 24px;') > -1).toBe(true);
-    expect(childNodeLeaf.attributes('style').indexOf('padding-left: 24px;') > -1).toBe(true);
+    expect(childNodes[0].attributes('style')).toContain('padding-left: 0px');
+    expect(childNodes[1].attributes('style')).toContain('padding-left: 24px');
+    expect(childNodes[2].attributes('style')).toContain('padding-left: 24px');
   });
 
-  it.todo('Should render the style of node connection line correctly.');
+  it('The node should be highlighted when clicked.', async () => {
+    // 可点击且非高亮的的节点，点击之后应该高亮
+    expect(childNodes[1].find('.devui-tree-node__content').classes()).not.toContain('active');
+    await childNodes[1].find('.devui-tree-node__content').trigger('click');
+    expect(childNodes[1].find('.devui-tree-node__content').classes()).toContain('active');
 
-  it.todo('The node should be highlighted when clicked.');
+    // 点击非高亮节点，该节点高亮，已高亮节点应该取消高亮
+    expect(childNodes[2].find('.devui-tree-node__content').classes()).not.toContain('active');
+    await childNodes[2].find('.devui-tree-node__content').trigger('click');
+    expect(childNodes[2].find('.devui-tree-node__content').classes()).toContain('active');
+    expect(childNodes[1].find('.devui-tree-node__content').classes()).not.toContain('active');
+  });
 
-  it.todo('The node should be disabled and unclickable when disabled is set to true.');
+  it('The node should be disabled and unclickable when disabled is set to true.', async () => {
+    // 设置了 disabled: true 的节点为禁用态，不可点击
+    expect(childNodes[0].find('.devui-tree-node__content').classes()).not.toContain('active');
+    await childNodes[0].trigger('click');
+    expect(childNodes[0].find('.devui-tree-node__content').classes()).not.toContain('active');
+  });
 
   it('The node should expand and collapse correctly when the expand-collapse button is clicked.', async () => {
     // 初始状态，节点是展开的
-    expect(firstNode.classes()).toContain('devui-tree-node__open');
+    expect(childNodes[0].classes()).toContain('devui-tree-node__open');
 
     // 点击之后，节点收起
-    await wrapper.get('.devui-tree-node__folder:first-child').trigger('click');
+    await childNodes[0].get('.devui-tree-node__folder').trigger('click');
     await nextTick();
-    expect(firstNode.classes()).not.toContain('devui-tree-node__open');
+    expect(childNodes[0].classes()).not.toContain('devui-tree-node__open');
 
     // 再次点击，节点展开
-    await wrapper.get('.devui-tree-node__folder:first-child').trigger('click');
+    await childNodes[0].get('.devui-tree-node__folder').trigger('click');
     await nextTick();
-    expect(firstNode.classes()).toContain('devui-tree-node__open');
+    expect(childNodes[0].classes()).toContain('devui-tree-node__open');
   });
+
+  it.todo('Should render the style of node connection line correctly.');
 
   it.todo('The node should be disabled and unclickable when disableToggle is set to true.');
 });

--- a/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
@@ -3,7 +3,7 @@ import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
 import { Tree } from '../../';
 import { basicTreeData } from './basic-tree-data';
 
-describe('Basic tree should include rendering of nested nodes and responses to hover, click and expand/collapse events.', () => {
+describe('Basic tree', () => {
   let wrapper: VueWrapper<ComponentPublicInstance>;
   let childNodes: DOMWrapper<Element>[];
 

--- a/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/basic-tree/basic-tree.spec.tsx
@@ -36,10 +36,28 @@ describe('Basic tree', () => {
     expect(childNodes[childNodes.length - 1].text()).toBe('Leaf node 2');
   });
 
+  it('Should render expand-collapse button correctly.', () => {
+    expect(childNodes[0].find('.devui-tree-node__folder > svg').exists()).toBe(true);
+    expect(childNodes[0].find('.devui-tree-node__folder > svg').classes()).toContain('svg-icon');
+    expect(childNodes[0].find('.devui-tree-node__folder > svg').classes()).toContain('svg-icon-close');
+
+    expect(childNodes[1].find('.devui-tree-node__folder > svg').exists()).toBe(true);
+    expect(childNodes[1].find('.devui-tree-node__folder > svg').classes()).toContain('svg-icon');
+    expect(childNodes[1].find('.devui-tree-node__folder > svg').classes()).not.toContain('svg-icon-close');
+  });
+
   it('Should render the style of child node correctly.', () => {
     expect(childNodes[0].attributes('style')).toContain('padding-left: 0px');
+    expect(childNodes[0].find('.devui-tree-node__folder > .devui-tree-node__indent').exists()).toBe(false);
+
     expect(childNodes[1].attributes('style')).toContain('padding-left: 24px');
+    expect(childNodes[1].find('.devui-tree-node__folder > .devui-tree-node__indent').exists()).toBe(false);
+
     expect(childNodes[2].attributes('style')).toContain('padding-left: 24px');
+    expect(childNodes[2].find('.devui-tree-node__folder > .devui-tree-node__indent').exists()).toBe(true);
+
+    expect(childNodes[childNodes.length - 1].attributes('style')).toContain('padding-left: 0px');
+    expect(childNodes[childNodes.length - 1].find('.devui-tree-node__folder > .devui-tree-node__indent').exists()).toBe(true);
   });
 
   it('The node should be highlighted when clicked.', async () => {
@@ -57,6 +75,7 @@ describe('Basic tree', () => {
 
   it('The node should be disabled and unclickable when disabled is set to true.', async () => {
     // 设置了 disabled: true 的节点为禁用态，不可点击
+    expect(childNodes[0].find('.devui-tree-node__title').classes()).toContain('select-disabled');
     expect(childNodes[0].find('.devui-tree-node__content').classes()).not.toContain('active');
     await childNodes[0].trigger('click');
     expect(childNodes[0].find('.devui-tree-node__content').classes()).not.toContain('active');

--- a/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree-data.ts
+++ b/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree-data.ts
@@ -1,0 +1,58 @@
+import { TreeData } from '../../';
+
+export const checkableTreeData: TreeData = [
+  {
+    label: 'Parent node 1',
+    open: true,
+    children: [
+      {
+        label: 'Parent node 1-1',
+        open: true,
+        disableCheck: true,
+        children: [
+          {
+            label: 'Leaf node 1-1-1'
+          }
+        ]
+      },
+      {
+        label: 'Parent node 1-2',
+        open: true,
+        checked: true,
+        disableCheck: true,
+        children: [
+          {
+            label: 'Leaf node 1-2-1'
+          }
+        ]
+      },
+      {
+        label: 'Leaf node 1-3',
+      },
+      {
+        label: 'Leaf node 1-4',
+        checked: true,
+      },
+      {
+        label: 'Leaf node 1-5',
+        disableCheck: true,
+      },
+      {
+        label: 'Leaf node 1-6',
+        checked: true,
+        disableCheck: true,
+      },
+    ]
+  },
+  {
+    label: 'Parent node 2',
+    children: [
+      {
+        label: 'Leaf node 2-1'
+      }
+    ]
+  },
+  {
+    label: 'Leaf node 3',
+  }
+];

--- a/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree.spec.tsx
@@ -23,9 +23,16 @@ describe('Checkable tree', () => {
     wrapper.unmount();
   });
 
-  it.todo('Should render checkbox correctly.');
+  it('Should render checkbox correctly.', () => {
+    expect(childNodes[0].find('.devui-checkbox').exists()).toBe(true);
+    expect(childNodes[0].find('.devui-checkbox').classes()).toContain('unchecked');
+  });
 
-  it.todo('Should toggle the checked state of the node correctly.');
+  it('Should toggle the checked state of the node correctly.', async () => {
+    await childNodes[0].find('.devui-checkbox').trigger('click');
+    expect(childNodes[0].find('.devui-checkbox').classes()).toContain('active');
+    expect(childNodes[0].find('.devui-tree-node__content').classes()).not.toContain('active');
+  });
 
   it.todo('The checkbox should be checked when setting checked to true.');
 

--- a/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/checkable-tree/checkable-tree.spec.tsx
@@ -1,0 +1,33 @@
+import { ComponentPublicInstance } from 'vue';
+import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
+import { Tree } from '../../';
+import { checkableTreeData } from './checkable-tree-data';
+
+describe('Checkable tree', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance>;
+  let childNodes: DOMWrapper<Element>[];
+
+  beforeAll(() => {
+    wrapper = mount({
+      setup() {
+        return () => {
+          return <Tree data={checkableTreeData} checkable />;
+        };
+      },
+    });
+
+    childNodes = wrapper.findAll('.devui-tree-node');
+  });
+
+  afterAll(() => {
+    wrapper.unmount();
+  });
+
+  it.todo('Should render checkbox correctly.');
+
+  it.todo('Should toggle the checked state of the node correctly.');
+
+  it.todo('The checkbox should be checked when setting checked to true.');
+
+  it.todo('The checkbox can\'t  be checked when setting disableCheck to true.');
+});

--- a/packages/devui-vue/devui/tree/__tests__/node-merge/node-merge-data.ts
+++ b/packages/devui-vue/devui/tree/__tests__/node-merge/node-merge-data.ts
@@ -1,0 +1,18 @@
+import type { TreeData } from '../../';
+
+export const nodeMergeData: TreeData = [
+  {
+    label: 'Parent node 1',
+    children: [
+      {
+        label: 'Parent node 1-1',
+        open: true,
+        children: [
+          {
+            label: 'Leaf node 1-1-1',
+          }
+        ]
+      },
+    ]
+  }
+];

--- a/packages/devui-vue/devui/tree/__tests__/node-merge/node-merge.spec.tsx
+++ b/packages/devui-vue/devui/tree/__tests__/node-merge/node-merge.spec.tsx
@@ -1,0 +1,31 @@
+import { ComponentPublicInstance } from 'vue';
+import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
+import { Tree } from '../../';
+import { nodeMergeData } from './node-merge-data';
+
+describe('Tree node merge', () => {
+  let wrapper: VueWrapper<ComponentPublicInstance>;
+  let childNodes: DOMWrapper<Element>[];
+
+  beforeAll(() => {
+    wrapper = mount({
+      setup() {
+        return () => {
+          return <Tree data={nodeMergeData} />;
+        };
+      },
+    });
+
+    childNodes = wrapper.findAll('.devui-tree-node');
+  });
+
+  afterAll(() => {
+    wrapper.unmount();
+  });
+
+  it('The parent nodes should be merged into one node when all parent nodes hava only one child node', () => {
+    expect(childNodes).toHaveLength(2);
+    expect(childNodes[0].text()).toBe('Parent node 1 / Parent node 1-1');
+    expect(childNodes[1].text()).toBe('Leaf node 1-1-1');
+  });
+});

--- a/packages/devui-vue/devui/tree/__tests__/tree.spec.ts
+++ b/packages/devui-vue/devui/tree/__tests__/tree.spec.ts
@@ -2,15 +2,11 @@ describe('tree', () => {
   // 测试节点懒加载功能是否正常
   it.todo('should loading child nodes dynamicly when click open button');
 
-  // 当节点下只有一个子节点时，应该合并这些节点
-  it.todo('should merge nodes when there is only one child node');
-
   /**
-   * 测试嵌套节点渲染和基本交互
+   * basic-tree 测试嵌套节点渲染和基本交互
+   * node-merge 当节点下只有一个子节点时，应该合并这些节点
    * 测试节点懒加载功能是否正常
-   * 当节点下只有一个子节点时，应该合并这些节点
-   * 节点的勾选功能正常
-   * 勾选复选框的禁用状态正常
+   * 节点的勾选功能正常，勾选复选框的禁用状态正常
    * 父子check控制功能正常
    * 自定义图标功能正常
    * 节点的增删改（操作按钮）功能正常

--- a/packages/devui-vue/devui/tree/src/composables/use-merge-node.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-merge-node.ts
@@ -16,7 +16,7 @@ export default function useMergeNode(data: Ref<TreeItem[]>): IUseMergeNode {
     ) {
       return mergeObject(
         Object.assign({}, children[0], {
-          [labelName]: `${label} \\ ${children[0][labelName]}`
+          [labelName]: `${label} / ${children[0][labelName]}`
         })
       );
     }


### PR DESCRIPTION
增加以下单元测试：
- 应该正确渲染展开/收起按钮
- 点击节点时，该节点应该高亮
- 设置`disabled`为`true`时，节点应该禁用，不可点击
- 所有子节点均只有一个子节点时，应该折叠父节点
- 设置`checkable`为`true`时，应该在节点前面正确渲染`checkbox`
- 点击`checkbox`应该能正确勾选或取消勾选`checkbox`