### PR TITLE
fix(Slider): 修复disabled时input未禁用

### DIFF
--- a/packages/devui-vue/devui/slider/__tests__/slider.spec.ts
+++ b/packages/devui-vue/devui/slider/__tests__/slider.spec.ts
@@ -47,11 +47,14 @@ describe('d-slider', () => {
   it('slider disabled work', () => {
     const wrapper = mount(DSlider, {
       props: {
-        disabled: true
+        disabled: true,
+        showInput: true
       }
     });
     const slider = wrapper.find('.devui-slider__runway');
+    const input = wrapper.find('input');
     expect(slider.classes()).toContain('disabled');
+    expect(input.attributes('disabled')).toBe('');
   });
 
   it('slider tipsRenderer work', () => {

--- a/packages/devui-vue/devui/slider/src/slider.tsx
+++ b/packages/devui-vue/devui/slider/src/slider.tsx
@@ -100,7 +100,7 @@ export default defineComponent({
     const renderShowInput = () => {
       return props.showInput ? (
         <div class='devui-input__out-wrap'>
-          <input onInput={handleOnInput} value={inputValue.value + ''}></input>
+          <input onInput={handleOnInput} value={inputValue.value + ''} disabled={props.disabled}></input>
         </div>
       ) : (
         ''

--- a/packages/devui-vue/docs/components/slider/index.md
+++ b/packages/devui-vue/docs/components/slider/index.md
@@ -126,6 +126,8 @@ export default defineComponent({
 <template>
   <div class="slider-wrapper" style="padding:20px">
     <d-slider :min="minValue" :max="maxValue" disabled v-model="disabledValue"></d-slider>
+    <br style="margin-bottom: 20px" />
+    <d-slider :min="minValue" :max="maxValue" showInput disabled v-model="disabledValue"></d-slider>
   </div>
 </template>
 <script>


### PR DESCRIPTION
fix(Slider): 修复disabled时input未禁用 [#471](https://github.com/DevCloudFE/vue-devui/issues/471)