### PR TITLE
feat(Progress): add `percentageTextPlacement` `percentageTextColor` api

### DIFF
--- a/packages/devui-vue/devui/progress/__tests__/progress.spec.ts
+++ b/packages/devui-vue/devui/progress/__tests__/progress.spec.ts
@@ -47,6 +47,35 @@ describe('progress', () => {
       expect(wrapper.props().percentageText).toBe('30%');
     });
 
+    it('percentageTextPlacement should be rendered correctly', async () => {
+      const wrapper = mount(Progress, {
+        props: {  },
+      });
+      expect(wrapper.props().percentageTextPlacement).toBe('inside');
+      expect(wrapper.find('.devui-progress--line').element.children.length).toBe(1);
+      expect(wrapper.find('.devui-progress-bar').element.children.length).toBe(1);
+      expect(wrapper.find('.devui-progress-content').element.children.length).toBe(1);
+
+      await wrapper.setProps({ percentageTextPlacement: 'insideBg' });
+      expect(wrapper.find('.devui-progress--line').element.children.length).toBe(2);
+
+      await wrapper.setProps({ percentageTextPlacement: 'outside' });
+      expect(wrapper.find('.devui-progress-content').element.children.length).toBe(1);
+
+      await wrapper.setProps({  percentageText: '30%' });
+      expect(wrapper.find('.devui-progress-content').element.children.length).toBe(2);
+    });
+
+    it('percentageTextColor should be rendered correctly', async () => {
+      const wrapper = mount(Progress, {
+        props: {
+          percentageText: '30%',
+          percentageTextColor: 'green'
+        },
+      });
+      expect(wrapper.find('span').attributes('style').includes('color: green')).toBeTruthy();
+    });
+
     it('barbgcolor should be rendered correctly', () => {
       const wrapper = mount(Progress, {
         props: { barBgColor: '#5170ff' },

--- a/packages/devui-vue/devui/progress/src/progress-types.ts
+++ b/packages/devui-vue/devui/progress/src/progress-types.ts
@@ -42,6 +42,14 @@ export const progressProps = {
     type: Boolean,
     default: true,
   },
+  percentageTextPlacement: {
+    type: String,
+    default: 'inside',
+  },
+  percentageTextColor: {
+    type: String,
+    default: '',
+  },
 };
 
 export type ProgressProps = ExtractPropTypes<typeof progressProps>;

--- a/packages/devui-vue/devui/progress/src/progress.scss
+++ b/packages/devui-vue/devui/progress/src/progress.scss
@@ -1,28 +1,61 @@
 @import '../../styles-var/devui-var.scss';
 
-.devui-progress--line {
-  position: relative;
-  background: $devui-dividing-line;
+.devui-progress-content {
+  display: flex;
+  flex-wrap: nowrap;
 
-  .devui-progress-bar {
-    width: 0;
-    height: 100%;
-    transition: width 0.6s ease;
-    background-color: #5e7ce0;
+  .devui-progress--line {
+    width: 100%;
+    position: relative;
+    background: $devui-dividing-line;
+
+    .devui-progress-bar {
+      width: 0;
+      height: 100%;
+      transition: width 0.6s ease;
+      background-color: #5e7ce0;
+
+      > span {
+        display: block;
+        white-space: nowrap;
+        color: $devui-light-text;
+        font-size: 12px;
+        line-height: 1.5;
+        padding: 0 10px;
+      }
+    }
+
+    > span {
+      display: block;
+      white-space: nowrap;
+      color: $devui-light-text;
+      text-align: center;
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 100%;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .inside {
+      text-align: center;
+    }
+
+    .insideLeft {
+      text-align: left;
+    }
+
+    .insideRight {
+      text-align: right;
+    }
   }
 
   > span {
-    display: block;
-    white-space: nowrap;
-    color: $devui-light-text;
+    min-width: 46px;
+    padding: 0 5px;
     text-align: center;
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 100%;
-    font-size: 12px;
-    line-height: 1.5;
   }
 }
 

--- a/packages/devui-vue/devui/progress/src/progress.tsx
+++ b/packages/devui-vue/devui/progress/src/progress.tsx
@@ -7,7 +7,11 @@ export default defineComponent({
   name: 'DProgress',
   props: progressProps,
   setup(props: ProgressProps) {
-    const { height, percentage, percentageText, barBgColor, isCircle, strokeWidth, showContent } = toRefs(props);
+    const {
+      height, percentage, percentageText,
+      percentageTextPlacement, percentageTextColor,
+      barBgColor, isCircle, strokeWidth, showContent
+    } = toRefs(props);
 
     const normalPercentage = ref(0);
 
@@ -53,7 +57,11 @@ export default defineComponent({
 
     setCircleProgress();
 
-    watch([height, normalPercentage, percentageText, barBgColor, isCircle, strokeWidth, showContent], () => {
+    watch([
+      height, normalPercentage, percentageText,
+      percentageTextPlacement, percentageTextColor,
+      barBgColor, isCircle, strokeWidth, showContent
+    ], () => {
       setCircleProgress();
     });
 
@@ -63,34 +71,59 @@ export default defineComponent({
     };
   },
   render() {
-    const { height, normalPercentage, percentageText, barBgColor, isCircle, strokeWidth, showContent, data, $slots } = this;
+    const {
+      height, normalPercentage, percentageText,
+      percentageTextPlacement, percentageTextColor,
+      barBgColor, isCircle, strokeWidth, showContent,
+      data, $slots } = this;
 
-    const progressLine = (
-      <div
-        class="devui-progress--line"
-        style={{
-          height: height,
-          borderRadius: height,
-        }}>
-        <div
-          class="devui-progress-bar"
-          style={{
-            height: height,
-            borderRadius: height,
-            width: `${normalPercentage}%`,
-            backgroundColor: barBgColor,
-          }}
-        />
+    const isOutside = percentageTextPlacement === 'outside';
+    const isInsideBg = percentageTextPlacement === 'insideBg';
+
+    const createPercentageText = () => {
+      return (
         <span
           style={{
             lineHeight: height,
+            color: percentageTextColor
           }}>
           {percentageText}
         </span>
+      );
+    };
+
+    const progressLine = (
+      <div class="devui-progress-content">
+        <div
+          class="devui-progress--line"
+          style={{
+            height: height,
+            borderRadius: height,
+          }}>
+          <div
+            class={["devui-progress-bar", percentageTextPlacement]}
+            style={{
+              height: height,
+              borderRadius: height,
+              width: `${normalPercentage}%`,
+              backgroundColor: barBgColor,
+            }}
+          >
+            {
+              !isOutside && !isInsideBg ? createPercentageText() : null
+            }
+          </div>
+          {
+            isInsideBg ? createPercentageText() : null
+          }
+        </div>
+        {
+          isOutside && !!percentageText ? createPercentageText() : null
+        }
       </div>
     );
 
-    const textElement = <span class="devui-progress-circle-text">{normalPercentage}%</span>;
+    const textElement = <span class="devui-progress-circle-text" style={{ color: percentageTextColor }}>{normalPercentage}%</span>;
 
     const progressCircle = (
       <div class="devui-progress-circle">

--- a/packages/devui-vue/docs/components/progress/index.md
+++ b/packages/devui-vue/docs/components/progress/index.md
@@ -41,6 +41,80 @@
 
 :::
 
+### 设置文字位置
+
+提供了5种位置选择
+
+::: demo
+
+```vue
+<template>
+  <section class="devui-code-box-demo">
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideLeft" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideRight" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideBg" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="outside" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-button @click="minus">减 10%</d-button> <d-button @click="add">增 10%</d-button>
+    </div>
+  </section>
+</template>
+<script>
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup () {
+    const percentageRef = ref(60)
+
+    const add = () => {
+      percentageRef.value += 10
+      if (percentageRef.value > 100) {
+        percentageRef.value = 0
+      }
+    }
+
+    const minus = () => {
+      percentageRef.value -= 10
+      if (percentageRef.value < 0) {
+        percentageRef.value = 100
+      }
+    }
+
+    return {
+      percentage: percentageRef,
+      add,
+      minus
+    }
+  }
+})
+</script>
+<style>
+.progress-container {
+  margin-bottom: 20px;
+}
+.devui-code-box-demo {
+  border-bottom: 1px dashed #dfe1e6;
+  padding: 16px 0;
+  .progress-container {
+    margin-bottom: 20px;
+  }
+}
+</style>
+```
+
+:::
+
 ### 圆环用法
 
 基本的进度和文字配置。
@@ -92,14 +166,63 @@
 
 :::
 
+### 自定义颜色
+
+如果你觉得内置的颜色不行。
+
+::: demo
+
+```vue
+<template>
+  <section class="devui-code-box-demo">
+  <div class="progress-container-circle">
+      <d-progress :isCircle="true" :percentage="80" barBgColor="#e056fd" :showContent="false"> </d-progress>
+    </div>
+    <div class="progress-container-circle">
+      <d-progress :isCircle="true" :percentage="80" barBgColor="#22a6b3" percentage-text-color="#22a6b3"> </d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="80" barBgColor="#badc58" percentage-text-color="#eb4d4b" percentageText="80%"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="80" barBgColor="orange" percentage-text-placement="outside" percentage-text-color="orange" percentageText="80%"></d-progress>
+    </div>
+  </section>
+</template>
+<style>
+.progress-container-circle {
+  height: 130px;
+  width: 130px;
+  font-size: 20px;
+  display: inline-block;
+  margin-right: 10px;
+  margin-bottom: 20px;
+}
+.progress-container {
+  margin-bottom: 20px;
+}
+.devui-code-box-demo {
+  border-bottom: 1px dashed #dfe1e6;
+  padding: 16px 0;
+  .progress-container {
+    margin-bottom: 20px;
+  }
+}
+</style>
+```
+
+:::
+
 ### Progress 参数
 
 | 参数名          | 类型      | 默认值  | 描述                                                     | 跳转 Demo             |
 | :-------------- | :-------- | :------ | :------------------------------------------------------- | :-------------------- |
 | percentage      | `number`  | 0       | 可选，进度条的值最大为 100                               | [基本用法](#基本用法) |
 | percentage-text | `string`  | --      | 可选，进度条当前值的文字说明比如：'30%' \| '4/5'         | [基本用法](#基本用法) |
-| bar-bg-color    | `string`  | #5170ff | 可选，进度条的颜色显示，默认为天蓝色                     | [基本用法](#基本用法) |
 | height          | `string`  | 20px    | 可选，进度条的高度值，默认值为 20px                      | [基本用法](#基本用法) |
+| percentage-text-placement  | `'insideLeft'\|'inside'\|`<br/> `'insideRight'\|'outside'\|`<br/>`'insideBg'`  | inside   | 可选，设置进度条的文字说明位置                    | [设置文字位置](#设置文字位置) |
 | is-circle       | `boolean` | false   | 可选， 显示进度条是否为圈形                              | [圆环用法](#圆环用法) |
 | stroke-width    | `number`  | 6       | 可选，设置圈形进度条宽度，单位是进度条与画布宽度的百分比 | [圆环用法](#圆环用法) |
 | show-content    | `boolean` | true    | 可选，设置圈形进度条内是否展示内容                       | [圆环用法](#圆环用法) |
+| bar-bg-color    | `string`  | #5170ff | 可选，进度条的颜色显示，默认为天蓝色                     | [自定义颜色](#自定义颜色) |
+| percentage-text-color          | `string`  | ''    | 可选，设置进度条的文字说明颜色                     | [自定义颜色](#自定义颜色) |

--- a/packages/devui-vue/docs/en-US/components/progress/index.md
+++ b/packages/devui-vue/docs/en-US/components/progress/index.md
@@ -37,6 +37,80 @@ Basic progress and text configuration.
 ```
 :::
 
+### Set Text Position
+
+Five location options are provided
+
+::: demo
+
+```vue
+<template>
+  <section class="devui-code-box-demo">
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideLeft" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideRight" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="insideBg" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress percentage-text-placement="outside" :percentage="percentage" :percentageText="`${percentage}%`"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-button @click="minus">minus 10%</d-button> <d-button @click="add">add 10%</d-button>
+    </div>
+  </section>
+</template>
+<script>
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup () {
+    const percentageRef = ref(60)
+
+    const add = () => {
+      percentageRef.value += 10
+      if (percentageRef.value > 100) {
+        percentageRef.value = 0
+      }
+    }
+
+    const minus = () => {
+      percentageRef.value -= 10
+      if (percentageRef.value < 0) {
+        percentageRef.value = 100
+      }
+    }
+
+    return {
+      percentage: percentageRef,
+      add,
+      minus
+    }
+  }
+})
+</script>
+<style>
+.progress-container {
+  margin-bottom: 20px;
+}
+.devui-code-box-demo {
+  border-bottom: 1px dashed #dfe1e6;
+  padding: 16px 0;
+  .progress-container {
+    margin-bottom: 20px;
+  }
+}
+</style>
+```
+
+:::
+
 ### Circle Usage
 Basic progress and text configuration.
 
@@ -90,14 +164,63 @@ Basic progress and text configuration.
 ```
 :::
 
+### Custom Color
+
+If you think the built-in colors don't work.
+
+::: demo
+
+```vue
+<template>
+  <section class="devui-code-box-demo">
+  <div class="progress-container-circle">
+      <d-progress :isCircle="true" :percentage="80" barBgColor="#e056fd" :showContent="false"> </d-progress>
+    </div>
+    <div class="progress-container-circle">
+      <d-progress :isCircle="true" :percentage="80" barBgColor="#22a6b3" percentage-text-color="#22a6b3"> </d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="80" barBgColor="#badc58" percentage-text-color="#eb4d4b" percentageText="80%"></d-progress>
+    </div>
+    <div class="progress-container">
+      <d-progress :percentage="80" barBgColor="orange" percentage-text-placement="outside" percentage-text-color="orange" percentageText="80%"></d-progress>
+    </div>
+  </section>
+</template>
+<style>
+.progress-container-circle {
+  height: 130px;
+  width: 130px;
+  font-size: 20px;
+  display: inline-block;
+  margin-right: 10px;
+  margin-bottom: 20px;
+}
+.progress-container {
+  margin-bottom: 20px;
+}
+.devui-code-box-demo {
+  border-bottom: 1px dashed #dfe1e6;
+  padding: 16px 0;
+  .progress-container {
+    margin-bottom: 20px;
+  }
+}
+</style>
+```
+
+:::
+
 ### API
 #### d-progress parameter
 | Parameter | Type | Default | Description | Jump to Demo |
 | :---: | :---: | :---: | :---: | :---: |
 | percentage | `number` | 0 | Optional. The maximum value of the progress bar is 100. | [Basic Usage](#basic-usage) |
 | percentageText |  `string` | -- | Optional. Text description of the current value of the progress bar, for example, '30%'\|'4/5' | [Basic Usage](#basic-usage) |
-| barBgColor |  `string` | #5170ff | Optional. Color of the progress bar. The default value is sky blue. | [Basic Usage](#basic-usage) |
 | height |  `string` | 20px | Optional. The default value is 20px. | [Basic Usage](#basic-usage) |
+| percentageTextPlacement  | `'insideLeft'\|'inside'\|`<br/> `'insideRight'\|'outside'\|`<br/>`'insideBg'`  | inside   | Optional. Set the text description position of the progress bar                    | [Set Text Position](#set-text-position) |
 | isCircle |  `boolean` | false | Optional. Whether the progress bar is displayed in a circle. | [Circle Usage](#circle-usage) |
 | strokeWidth |  `number` | 6 | Optional. Sets the width of the progress bar. The unit is the percentage of the progress bar to the width of the canvas. | [Circle Usage](#circle-usage) |
 | showContent |  `boolean` | true | Optional. Sets whether to display content in the circle progress bar. | [Circle Usage](#circle-usage) |
+| barBgColor |  `string` | #5170ff | Optional. Color of the progress bar. The default value is sky blue. | [Basic Usage](#basic-usage) |
+| percentage-text-color          | `string`  | ''    | Optional. Set the text description color of the progress bar                     | [Custom Color](#custom-color) |


### PR DESCRIPTION
- [x] 新增进度条的文字说明位置设置
- [x] 新增进度条的文字说明颜色设置

设置进度条的文字说明位置
<img width="878" alt="image" src="https://user-images.githubusercontent.com/34124930/164895662-8333fc97-768d-4b68-82a5-2b495a19ecec.png">
设置进度条的文字说明颜色
<img width="894" alt="image" src="https://user-images.githubusercontent.com/34124930/164895649-c9f7f24b-ddff-48f2-9e4e-0886dcca4ff3.png">
