### PR TITLE
fix(Button): Button组件形态为outline，类型为primary禁用的情况下，不应该有hover效果 (#575)。

### DIFF
--- a/packages/devui-vue/devui/button/src/button.scss
+++ b/packages/devui-vue/devui/button/src/button.scss
@@ -141,6 +141,8 @@
 
       &:disabled {
         opacity: 0.8;
+        color: $devui-brand-active;
+        border-color: $devui-form-control-line-active;
       }
     }
 


### PR DESCRIPTION
鼠标移入元素依然会触发 hover 设置颜色， disabled 设置了颜色就不会被覆盖。