### PR TITLE
fix(Button): variant为outline，icon为like时样式不正确

### DIFF
--- a/packages/devui-vue/devui/button/__tests__/button.spec.tsx
+++ b/packages/devui-vue/devui/button/__tests__/button.spec.tsx
@@ -7,7 +7,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button variant="solid">确定</Button>;
-        }
+        };
       }
     });
     expect(wrapper.find('.devui-btn').classes()).toContain('devui-btn-solid');
@@ -18,7 +18,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button size="sm">确定</Button>;
-        }
+        };
       }
     });
     expect(wrapper.find('.devui-btn-sm').exists()).toBeTruthy();
@@ -29,7 +29,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button type="submit">确定</Button>;
-        }
+        };
       }
     });
     expect(wrapper.find('button').attributes('type')).toBe('submit');
@@ -41,7 +41,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button onClick={handleClick}>确定</Button>;
-        }
+        };
       }
     });
     await wrapper.find('.devui-btn').trigger('click');
@@ -55,7 +55,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button loading={true} onClick={handleClick}>确定</Button>;
-        }
+        };
       }
     });
     await wrapper.trigger('click');
@@ -68,7 +68,7 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button disabled onClick={handleClick}>确定</Button>;
-        }
+        };
       }
     });
     await wrapper.trigger('click');
@@ -81,9 +81,25 @@ describe('d-button', () => {
       setup() {
         return () => {
           return <Button>{btnText}</Button>;
-        }
+        };
       }
     });
     expect(wrapper.text()).toEqual(btnText);
+  });
+
+  it('showContour shoule be rendered correctly', async () => {
+    const btnText = 'vue3 devui';
+    const wrapper = mount({
+      setup() {
+        return () => {
+          return <Button variant="solid">{btnText}</Button>;
+        };
+      }
+    });
+    await wrapper.setProps({ showContour: true });
+    expect(wrapper.find('.devui-btn').attributes('class').includes('devui-btn-contour')).toBeFalsy();
+
+    await wrapper.setProps({ variant: 'text' });
+    expect(wrapper.find('.devui-btn').attributes('class').includes('devui-btn-contour')).toBeTruthy();
   });
 });

--- a/packages/devui-vue/devui/button/src/button-types.ts
+++ b/packages/devui-vue/devui/button/src/button-types.ts
@@ -28,6 +28,10 @@ export const buttonProps = {
     type: Boolean,
     default: false,
   },
+  showContour: {
+    type: Boolean,
+    default: false
+  }
 } as const;
 
 export type ButtonProps = ExtractPropTypes<typeof buttonProps>;

--- a/packages/devui-vue/devui/button/src/button.scss
+++ b/packages/devui-vue/devui/button/src/button.scss
@@ -235,7 +235,7 @@
     min-width: 72px;
   }
 
-  &.devui-btn-icon {
+  &.devui-btn-contour {
     &:hover,
     &:focus {
       border: 1px solid $devui-list-item-hover-bg;
@@ -283,7 +283,7 @@
   align-items: center;
   justify-content: center;
 
-  &.devui-btn-icon {
+  &.devui-btn-contour {
     padding: 8px;
     line-height: 1em;
     border: 1px solid transparent;
@@ -310,7 +310,7 @@
     }
   }
 
-  &:not(.devui-btn-icon) {
+  &:not(.devui-btn-contour) {
     .icon-fix {
       font-size: $devui-font-size-icon;
     }

--- a/packages/devui-vue/devui/button/src/use-button.ts
+++ b/packages/devui-vue/devui/button/src/use-button.ts
@@ -17,7 +17,7 @@ export default function useButton(props: ButtonProps, ctx: SetupContext): UseBut
     [`devui-btn-${props.variant}-${props.color || defaultColor}`]: true,
     [`devui-btn-${props.size}`]: true,
     'devui-btn-icon-wrap': props.icon,
-    'devui-btn-icon': props.icon && !hasContent.value && props.variant !== 'solid',
+    'devui-btn-contour': props.variant === 'text' && props.showContour,
     'devui-btn-is-loading': props.loading,
   }));
 

--- a/packages/devui-vue/docs/components/button/index.md
+++ b/packages/devui-vue/docs/components/button/index.md
@@ -137,6 +137,23 @@ export default {
 
 :::
 
+### 文字按钮轮廓
+
+你可以给`variant="text"`的按钮添加背景轮廓
+
+:::demo
+
+```vue
+<template>
+  <div class="demo-spacing">
+    <d-button icon="add" variant="text" showContour></d-button>
+    <d-button variant="text" showContour>show text hover background</d-button>
+  </div>
+</template>
+```
+
+:::
+
 ### Button 参数
 
 | 参数名   | 类型                              | 默认        | 说明                  | 跳转 Demo                 |
@@ -147,6 +164,7 @@ export default {
 | icon     | `string`                          | --          | 可选，自定义按钮图标  | [图标按钮](#图标按钮)     |
 | disabled | `boolean`                         | false       | 可选，是否禁用 button | [禁用状态](#禁用状态)     |
 | loading  | `boolean`                         | false       | 可选，设置加载中状态  | [加载中状态](#加载中状态) |
+| showContour  | `boolean`                         | false       | 可选，设置文字按钮的背景轮廓，只在`variant="text"`属性下生效  | [文字按钮轮廓](#文字按钮轮廓) |
 
 ### Button 类型定义
 


### PR DESCRIPTION
修复variant为outline，icon为like时样式不正确 （[#576 ](https://github.com/DevCloudFE/vue-devui/issues/576)）

受到了`.devui-btn-icon`这个样式的影响， 添加了hover的背景色， 我修复了上面的问题，但是我把这个变成了一个新的特性

`showContour`这个属性只在`variant="text" `属性下生效， 我不知道这样添加这个特性是否合理
`<d-button icon="add" variant="text" showContour></d-button>`
![image](https://user-images.githubusercontent.com/34124930/165496732-30ba74e0-a96d-4a3b-a2b0-a049e0aa45f3.png)
