### PR TITLE
docs(grid): 使用css变量解决Grid组件组件黑暗主题下背景颜色错误

### DIFF
--- a/packages/devui-vue/docs/components/grid/index.md
+++ b/packages/devui-vue/docs/components/grid/index.md
@@ -49,11 +49,10 @@
   line-height: 44px;
 }
 .docs-devui-row .devui-col:nth-of-type(2n + 1) {
-  background: #f8f8f8;
+  background: var(--devui-global-bg);
 }
 .docs-devui-row .devui-col:nth-of-type(2n) {
-  background: #99b0ff;
-  color: #fff;
+  background: var(--devui-brand);
 }
 </style>
 ```
@@ -187,10 +186,10 @@
   background: transparent !important;
 }
 .col-gutter:nth-of-type(2n + 1) > .col-child {
-  background: #f8f8f8;
+  background: var(--devui-global-bg);
 }
 .col-gutter:nth-of-type(2n) > .col-child {
-  background: #99b0ff;
+  background: var(--devui-brand);
 }
 </style>
 ```


### PR DESCRIPTION
其他组件文档也有类似情况,原因都是把颜色值写死了. #563 