### PR TITLE
fix(tree): 如果是叶子结点，不需要尝试获取子节点，以提升性能

### DIFF
--- a/packages/devui-vue/devui/tree/src/composables/use-core.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-core.ts
@@ -23,7 +23,7 @@ export default function(){
             if (excludeNodes.map(innerNode => innerNode.id).includes(item.id)) {
               continue;
             }
-            if (item.expanded !== true) {
+            if (item.expanded !== true && !item.isLeaf) {
               excludeNodes = getChildren(item);
             }
             result.push(item);


### PR DESCRIPTION
开发虚拟滚动的时候试着渲染了150条数据，发现性能损耗有点大，Tree组件耗时 1000+ms，排查了一下，没有子节点不就不尝试获取子节点能大大提升性能。
<img width="1306" alt="image" src="https://user-images.githubusercontent.com/40119767/173169478-b468b9dd-fba0-431a-836a-d28ac21cbf77.png">
<img width="1245" alt="image" src="https://user-images.githubusercontent.com/40119767/173169503-48225592-32ce-4eb9-bd8b-8f72e4c6819f.png">
