### PR TITLE
fix(search): 修复点击search组件区域内按钮会使得组件失焦的问题

### DIFF
--- a/packages/devui-vue/devui/search/__tests__/search.spec.ts
+++ b/packages/devui-vue/devui/search/__tests__/search.spec.ts
@@ -67,6 +67,7 @@ describe('search test', () => {
     await clear.trigger('click');
     expect(input.element.value).toBe('');
     expect(value.value).toBe('');
+    expect(input.element === document.activeElement).toBe(true);
 
     // test disabled
     expect(input.attributes('disabled')).toBe(undefined);
@@ -98,10 +99,12 @@ describe('search test', () => {
     });
     const search = wrapper.find(dotSearchClass);
     const searchBtn = search.find(dotIconSearchClass);
+    const input = search.find('input');
     await searchBtn.trigger('click');
     await onSearch((str) => {
       expect(str).toBe('test');
     });
     expect(onSearch).toBeCalledTimes(1);
+    expect(input.element === document.activeElement).toBe(true);
   });
 });

--- a/packages/devui-vue/devui/search/__tests__/search.spec.ts
+++ b/packages/devui-vue/devui/search/__tests__/search.spec.ts
@@ -67,6 +67,8 @@ describe('search test', () => {
     await clear.trigger('click');
     expect(input.element.value).toBe('');
     expect(value.value).toBe('');
+
+    // test input focus after trigger clear button
     expect(input.element === document.activeElement).toBe(true);
 
     // test disabled
@@ -105,6 +107,8 @@ describe('search test', () => {
       expect(str).toBe('test');
     });
     expect(onSearch).toBeCalledTimes(1);
+
+    // test input focus after trigger search button
     expect(input.element === document.activeElement).toBe(true);
   });
 });

--- a/packages/devui-vue/devui/search/src/search.tsx
+++ b/packages/devui-vue/devui/search/src/search.tsx
@@ -50,7 +50,7 @@ export default defineComponent({
         onBlur: onBlur,
       };
       return (
-        <div class={rootClasses.value}>
+        <label class={rootClasses.value}>
           {props.iconPosition === 'left' && (
             <div class={ns.e('icon')} onClick={onClickHandle}>
               <d-icon name="search" size="inherit" key="search"></d-icon>
@@ -67,7 +67,7 @@ export default defineComponent({
               <d-icon name="search" size="inherit" key="search"></d-icon>
             </div>
           )}
-        </div>
+        </label>
       );
     };
   },


### PR DESCRIPTION
问题来源：https://github.com/DevCloudFE/vue-devui/issues/997
1. 修复点击clear按钮以及search按钮时，input输入框将会失焦的问题（使用label标签包裹）
2. 增加对该问题的测试except