### PR TITLE
refactor(menu): 重构类名

### DIFF
--- a/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
+++ b/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
@@ -1,5 +1,5 @@
 import { clearSelect } from '../../composables/use-layer-operate';
-import { defineComponent, getCurrentInstance, onMounted, ref, Transition, watch, inject, Ref, reactive, toRefs } from 'vue';
+import { defineComponent, getCurrentInstance, onMounted, ref, Transition, watch, inject, Ref, reactive, toRefs, computed } from 'vue';
 import { MenuItemProps, menuItemProps } from './menu-item-types';
 import { initSelect, addActiveParent, changeRoute } from './use-menu-item';
 import { useClick } from '../../composables/use-click';
@@ -33,13 +33,12 @@ export default defineComponent({
     const useRouter = inject('useRouter') as boolean;
     const router = instance?.appContext.config.globalProperties.$router as Router;
 
-    const classObject: Record<string, boolean> = reactive({
+    const classObject = computed(()=>({
       [`${ns.b()}-item`]: true,
       [`${ns.b()}-item-isCollapsed`]: isCollapsed.value,
-      [`${ns.b()}-isCollapsed-item`]: isCollapsed.value,
       [menuItemSelect]: isSelect.value,
       [menuItemDisabled]: disabled.value,
-    });
+    }));
     const onClick = (e: MouseEvent) => {
       e.stopPropagation();
       const ele = e.currentTarget as HTMLElement;
@@ -80,13 +79,13 @@ export default defineComponent({
     const icons = <span class={`${ns.b()}-icon`}>{ctx.slots.icon?.()}</span>;
     const menuItems = ref(null);
     watch(disabled, () => {
-      classObject[menuItemSelect] = false;
+      classObject.value[menuItemSelect] = false;
     });
     watch(
       () => defaultSelectKey,
       (n) => {
         isSelect.value = initSelect(n, key, multiple, disabled);
-        classObject[menuItemSelect] = isSelect.value;
+        classObject.value[menuItemSelect] = isSelect.value;
       }
     );
     onMounted(() => {
@@ -121,11 +120,12 @@ export default defineComponent({
         }
       }
     });
+
     return () => {
       return mode.value === 'vertical' ? (
         <div class={`${ns.b()}-item-vertical-wrapper`}>
           <li
-            class={[classObject, props['disabled'] ? menuItemDisabled : '', isLayer1.value ? 'layer_1' : '']}
+            class={classObject.value}
             onClick={onClick}
             ref={menuItems}>
             {ctx.slots.icon !== undefined && icons}
@@ -142,7 +142,7 @@ export default defineComponent({
         </div>
       ) : (
         <li
-          class={[classObject, props['disabled'] ? menuItemDisabled : '', isLayer1.value ? 'layer_1' : '']}
+          class={classObject.value}
           onClick={onClick}
           ref={menuItems}>
           {ctx.slots.icon !== undefined && icons}

--- a/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
+++ b/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
@@ -22,11 +22,11 @@ export default defineComponent({
   setup(props: SubMenuProps, ctx) {
     const isShow = ref(true);
     const {
-      vnode: { key },
+      vnode: { key }
     } = getCurrentInstance() as ComponentInternalInstance;
     const key_ = String(key);
     const isOpen = ref(false);
-    const defaultOpenKeys = inject('openKeys') as string[];
+    const defaultOpenKeys = inject('openKeys') as Ref<string[]>;
     const indent = inject('defaultIndent');
     const isCollapsed = inject('isCollapsed') as Ref<boolean>;
     const mode = inject('mode') as Ref<string>;
@@ -36,7 +36,7 @@ export default defineComponent({
     if (key_ === 'null') {
       console.warn(`[devui][menu]: Key can not be null`);
     } else {
-      if (defaultOpenKeys.includes(key_)) {
+      if (defaultOpenKeys.value.includes(key_)) {
         isOpen.value = true;
       } else {
         isOpen.value = false;
@@ -93,12 +93,12 @@ export default defineComponent({
     watch(
       () => defaultOpenKeys,
       (n) => {
-        if (n.includes(key_)) {
+        if (n.value.includes(key_)) {
           isOpen.value = true;
         } else {
           isOpen.value = false;
         }
-      }
+      },{deep: true}
     );
     onMounted(() => {
       const el = title.value as unknown as HTMLElement;
@@ -147,7 +147,7 @@ export default defineComponent({
               {props.title}
             </span>
             <i
-              v-show={!isCollapsed.value}
+              v-show={!isCollapsed.value && key !== 'overflowContainer'}
               class={{
                 'icon icon-chevron-up': class_layer.value !== `layer_${subMenuClass}`,
                 'icon icon-chevron-right': class_layer.value === `layer_${subMenuClass}`,

--- a/packages/devui-vue/devui/menu/src/components/sub-menu/use-sub-menu.ts
+++ b/packages/devui-vue/devui/menu/src/components/sub-menu/use-sub-menu.ts
@@ -9,26 +9,21 @@ const menuItemHorizontalWrapperShow = `${ns.b()}-item-horizontal-wrapper-show`;
 type mouseEventName = 'mouseenter' | 'mouseleave';
 export function useShowSubMenu(eventName: mouseEventName, e: MouseEvent, wrapper: HTMLElement): void {
   const target = e.currentTarget as EventTarget as HTMLElement;
-  const subMenuTitle = target.children[0];
   const targetParent = target.parentElement;
   const wrapperChildren = wrapper.children;
   wrapper.style.padding = `0 20px !important`;
   if (eventName === 'mouseenter') {
-    wrapper.classList.remove(menuItemHorizontalWrapperHidden);
-    wrapper.classList.add(menuItemHorizontalWrapperShow);
     if (targetParent?.tagName === 'DIV') {
       wrapper.classList.add(`${ns.b()}-item-horizontal-wrapper-level`);
-      const { top, left } = target.getClientRects()[0];
-      const x = left + targetParent.clientWidth;
-      const y = top;
-      wrapper.style.top = `${y}px`;
-      wrapper.style.left = `${x}px`;
+      const { width } = target.getClientRects()[0];
+      wrapper.style.top = `0px`;
+      wrapper.style.left = `${width}px`;
     } else {
-      const { top, left, height } = subMenuTitle.getClientRects()[0];
-      const y = top + height;
-      wrapper.style.top = `${y}px`;
-      wrapper.style.left = `${left}px`;
+      wrapper.style.top = `26px`;
+      wrapper.style.left = `0px`;
     }
+    wrapper.classList.remove(menuItemHorizontalWrapperHidden);
+    wrapper.classList.add(menuItemHorizontalWrapperShow);
     for (let i = 0; i < wrapperChildren.length; i++) {
       const ul = wrapperChildren[i];
       if (ul.tagName === 'UL' && ul.classList.contains(subNs.b())) {
@@ -36,10 +31,14 @@ export function useShowSubMenu(eventName: mouseEventName, e: MouseEvent, wrapper
         (ul as HTMLElement).addEventListener('mouseenter', (ev: MouseEvent) => {
           ev.stopPropagation();
           useShowSubMenu('mouseenter', ev, levelUlWrapper as Element as HTMLElement);
+          levelUlWrapper.classList.remove(menuItemHorizontalWrapperHidden);
+          levelUlWrapper.classList.add(menuItemHorizontalWrapperShow);
         });
         (ul as HTMLElement).addEventListener('mouseleave', (ev: MouseEvent) => {
           ev.stopPropagation();
           useShowSubMenu('mouseleave', ev, levelUlWrapper as Element as HTMLElement);
+          levelUlWrapper.classList.remove(menuItemHorizontalWrapperShow);
+          levelUlWrapper.classList.add(menuItemHorizontalWrapperHidden);
         });
       }
     }

--- a/packages/devui-vue/devui/menu/src/styles/clear.scss
+++ b/packages/devui-vue/devui/menu/src/styles/clear.scss
@@ -7,5 +7,6 @@
   ul,
   li {
     list-style: none;
+    white-space: nowrap;
   }
 }

--- a/packages/devui-vue/devui/menu/src/styles/horizontal.scss
+++ b/packages/devui-vue/devui/menu/src/styles/horizontal.scss
@@ -114,17 +114,21 @@
     }
 
     div.#{$devui-prefix}-menu-item-horizontal-wrapper {
-      transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
+      transition:
+        all $devui-animation-duration-fast $devui-animation-ease-in-smooth,
+        left 0 linear;
       background: $devui-menu-bg;
+      z-index: $devui-z-index-modal;
     }
 
     div.#{$devui-prefix}-menu-item-horizontal-wrapper-show {
+      transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
       opacity: 1;
       visibility: visible;
-      max-height: calc(100vh - 100px);
+      max-height: 100vh;
       padding: 10px 0 !important;
       border-radius: 8px;
-      position: fixed;
+      position: absolute;
 
       .#{$devui-prefix}-menu-item {
         margin-top: 5px;
@@ -146,13 +150,12 @@
 
     div.#{$devui-prefix}-menu-item-horizontal-wrapper-hidden {
       transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
-      position: fixed;
-      // margin-top: -5px;
+      visibility: hidden;
+      position: absolute;
       padding: 0 !important;
       max-height: 0;
       overflow: hidden;
       opacity: 0;
-
       .#{$devui-prefix}-menu-item {
         margin-top: 5px;
       }

--- a/packages/devui-vue/devui/menu/src/styles/vertical.scss
+++ b/packages/devui-vue/devui/menu/src/styles/vertical.scss
@@ -10,10 +10,6 @@
   border-right: $devui-line 1px solid;
   background: $devui-area !important;
 
-  * {
-    transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
-  }
-
   ::after {
     transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
     background: transparent;
@@ -29,11 +25,6 @@
       margin: 0 !important;
       background: $devui-block;
     }
-  }
-
-  li.#{$devui-prefix}-menu-isCollapsed-item {
-    padding: 0;
-    margin: auto;
   }
 
   &.#{$devui-prefix}-menu-collapsed {

--- a/packages/devui-vue/docs/components/menu/index.md
+++ b/packages/devui-vue/docs/components/menu/index.md
@@ -8,11 +8,11 @@ Menu 组件通常用于导航.
 
 ### 基本用法
 
-:::demo
+:::demo 如果屏幕尺寸过小，则会出现省略号
 
 ```vue
 <template>
-  <d-menu mode="horizontal" :default-select-keys="['home']" style="margin-bottom: 120px">
+  <d-menu mode="horizontal" :default-select-keys="['home']" style="margin-bottom: 120px" :width="width + 'px'">
     <d-menu-item key="home">
       <template #icon>
         <i class="icon-homepage"></i>
@@ -29,7 +29,14 @@ Menu 组件通常用于导航.
     <d-menu-item key="person">个人</d-menu-item>
     <d-menu-item key="custom" href="https://www.baidu.com"> Link To Baidu </d-menu-item>
   </d-menu>
+  <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+let width = ref(480);
+</script>
+
 ```
 
 :::
@@ -118,6 +125,64 @@ Menu 组件通常用于导航.
 </template>
 ```
 
+:::
+
+
+### 仅一项展开
+
+:::demo 通过子菜单状态改变事件修改```open-keys```数组达到效果
+
+``` vue
+  <template>
+    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px">
+      <d-sub-menu title="submenu-1" key="submenu-1">
+        <template #icon>
+          <i class="icon-infomation"></i>
+        </template>
+        <d-menu-item key="subemenu-item-1">
+          <span>submenu-item-1</span>
+        </d-menu-item>
+      </d-sub-menu>
+      <d-sub-menu title="submenu-2" key="submenu-2">
+        <template #icon>
+          <i class="icon-setting"></i>
+        </template>
+        <d-menu-item key="submenu-item-2">
+          <span>submenu-item-2</span>
+        </d-menu-item>
+      </d-sub-menu>
+      <d-sub-menu title="submenu-3" key="submenu-3">
+        <template #icon>
+          <i class="icon-setting"></i>
+        </template>
+        <d-menu-item key="submenu-item-2">
+          <span>submenu-item-2</span>
+        </d-menu-item>
+      </d-sub-menu>
+    </d-menu>
+  </template>
+
+  <script>
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    setup() {
+      const openKeys = ref(['submenu-1']);
+      const submenuChange = (e) => {
+        console.log(e)
+        openKeys.value.forEach(element => {
+          openKeys.value.shift()
+        });
+        openKeys.value.push(e.key)
+      };
+      return {
+        openKeys,
+        submenuChange,
+      };
+    },
+  });
+  </script>
+```
 :::
 
 ### 收缩菜单
@@ -249,7 +314,7 @@ export default defineComponent({
     </d-sub-menu>
   </d-menu>
   <br />
-  <d-slider :min="0" :max="480" v-model="width" tipsRenderer="px"></d-slider>
+  <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
 
 <script lang="ts" setup>

--- a/packages/devui-vue/docs/en-US/components/menu/index.md
+++ b/packages/devui-vue/docs/en-US/components/menu/index.md
@@ -1,42 +1,52 @@
-# Menu
+# Menu 菜单
 
-Menu component is usually used for navigation
+Menu usually used to navigation.
 
-### When to used.
+### When To Use
 
-When it comes to packing, arranging, and displaying a range of options.
+When you need to store, arrange and display a series of options
 
-### Basic Used
+### Basic
 
-:::demo
+:::demo If the screen size is too small, an ellipsis appears
 
 ```vue
 <template>
-  <d-menu mode="horizontal" :default-select-keys="['item1']">
-    <d-menu-item :key="'item1'">
+  <d-menu mode="horizontal" :default-select-keys="['home']" style="margin-bottom: 120px" :width="width + 'px'">
+    <d-menu-item key="home">
       <template #icon>
         <i class="icon-homepage"></i>
       </template>
-      首页
+      Home
     </d-menu-item>
-    <d-sub-menu title="课程">
-      <d-menu-item> C </d-menu-item>
-      <d-menu-item> Python </d-menu-item>
+    <d-sub-menu title="课程" key="course">
+      <d-menu-item key="c"> C </d-menu-item>
+      <d-sub-menu title="Python" key="python">
+        <d-menu-item key="basic"> basic </d-menu-item>
+        <d-menu-item key="advanced"> advanced </d-menu-item>
+      </d-sub-menu>
     </d-sub-menu>
-    <d-menu-item>个人</d-menu-item>
-    <d-menu-item href="https://www.baidu.com"> Link To Baidu </d-menu-item>
+    <d-menu-item key="person">个人</d-menu-item>
+    <d-menu-item key="custom" href="https://www.baidu.com"> Link To Baidu </d-menu-item>
   </d-menu>
-  <br /><br /><br /><br /><br /><br />
+  <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+let width = ref(480);
+</script>
+
 ```
 
 :::
 
-### custom icons.
+### Icon
 
-Sometimes we need declare icon for submenu or menu item. That we can use ```icon``` slot to declare icon of sub menu or menu item. At the same time, we can use ```css`` to make to make customized modifications for slot
+Sometimes. We need define some icon for subMenu or menuItem. We can use ```icon```slot to define icon. At the same time, we can also use CSS to customize the slot
 
 :::demo
+
 ```vue
 <template>
   <d-menu mode="horizontal">
@@ -44,43 +54,42 @@ Sometimes we need declare icon for submenu or menu item. That we can use ```icon
       <template #icon>
         <i class="icon-homepage"></i>
       </template>
-      主页
+      Home Page
     </d-menu-item>
-    <d-menu-item key="classes">
-      课程
-    </d-menu-item>
+    <d-menu-item key="course"> course </d-menu-item>
   </d-menu>
 </template>
 ```
+
 :::
 
-### vertical Menu
+### Vertical
 
-vertical menu usually used in back-end. sub-menu can Embed in a menu
+Vertical menus are generally widely used in the background, and submenus can be embedded in menus
 
 :::demo
 
 ```vue
 <template>
   <d-menu mode="vertical" :default-select-keys="['item1']" width="256px">
-    <d-menu-item key="item1" :disabled="isDisabled">
+    <d-menu-item key="item1">
       <template #icon>
         <i class="icon-homepage"></i>
       </template>
       <span>Home</span>
     </d-menu-item>
-    <d-sub-menu title="System">
+    <d-sub-menu title="System" key="system">
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item>
+      <d-menu-item key="system">
         <span>System item</span>
       </d-menu-item>
-      <d-sub-menu title="Setting">
+      <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item>
+        <d-menu-item key="setting">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -91,9 +100,9 @@ vertical menu usually used in back-end. sub-menu can Embed in a menu
 
 :::
 
-### default open
+### Default-Open
 
-Setting`open-keys`can change sub menu item opan state
+You can modify the expanded submenu items by setting 'open keys'
 
 :::demo
 
@@ -101,16 +110,16 @@ Setting`open-keys`can change sub menu item opan state
 <template>
   <d-menu width="256px" mode="vertical" :open-keys="['sub1', 'sub3']">
     <d-sub-menu key="sub1" title="sub1">
-      <d-menu-item> Sub1 > item1 </d-menu-item>
-      <d-menu-item> Sub1 > item2 </d-menu-item>
+      <d-menu-item key="Sub1-item1"> Sub1 > item1 </d-menu-item>
+      <d-menu-item key="Sub1-item2"> Sub1 > item2 </d-menu-item>
     </d-sub-menu>
     <d-sub-menu key="sub2" title="sub2">
-      <d-menu-item> Sub2 > item1 </d-menu-item>
-      <d-menu-item> Sub2 > item2 </d-menu-item>
+      <d-menu-item key="Sub2-item1"> Sub2 > item1 </d-menu-item>
+      <d-menu-item key="Sub2-item2"> Sub2 > item2 </d-menu-item>
     </d-sub-menu>
     <d-sub-menu key="sub3" title="sub3">
-      <d-menu-item> Sub3 > item1 </d-menu-item>
-      <d-menu-item> Sub3 > item2 </d-menu-item>
+      <d-menu-item key="Sub3-item1"> Sub3 > item1 </d-menu-item>
+      <d-menu-item key="Sub3-item2"> Sub3 > item2 </d-menu-item>
     </d-sub-menu>
   </d-menu>
 </template>
@@ -118,9 +127,7 @@ Setting`open-keys`can change sub menu item opan state
 
 :::
 
-### collapse menu
-
-To change `collapsed` can change menu collapsed status.
+### Collapsed
 
 :::demo
 
@@ -129,25 +136,25 @@ To change `collapsed` can change menu collapsed status.
   Collapsed
 </d-button>
 <template>
-  <d-menu mode="vertical" width="256px" :default-select-keys="['item1']" :collapsed="collapsed">
+  <d-menu :collapsed-indent="48" mode="vertical" width="256px" :default-select-keys="['item1']" :collapsed="collapsed">
     <d-menu-item key="item1" :disabled="isDisabled">
       <template #icon>
         <i class="icon-homepage"></i>
       </template>
       <span>Home</span>
     </d-menu-item>
-    <d-sub-menu title="System">
+    <d-sub-menu title="System" key="system">
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item>
+      <d-menu-item key="system">
         <span>System item</span>
       </d-menu-item>
-      <d-sub-menu title="Setting">
+      <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item>
+        <d-menu-item key="setting">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -167,32 +174,114 @@ const changeCollapsed = () => {
 
 :::
 
-### cancel multi-selection
+### Deselect
+
+The function of canceling multiple selection can only be used in menus that allow multiple selection. The menu item will trigger the 'deselect' event when canceling multiple selection.
 
 :::demo
 
 ```vue
 <template>
-  <d-menu :default-select-keys="['item1']" multiple width="256px">
+  <d-menu @select="select" @deselect="deselect" @submenu-change="submenuChange" :default-select-keys="['item1']" multiple width="256px">
     <d-menu-item key="item1"> Item1 </d-menu-item>
     <d-menu-item key="item2"> Item2 </d-menu-item>
-    <d-sub-menu title="Setting">
+    <d-sub-menu title="Setting" key="icon-setting">
       <template #icon>
         <i class="icon-setting"></i>
       </template>
-      <d-menu-item>
+      <d-menu-item key="setting">
         <span>Setting item</span>
       </d-menu-item>
     </d-sub-menu>
   </d-menu>
 </template>
+
+<script>
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  setup() {
+    const select = (e) => {
+      console.log(e);
+    };
+    const deselect = (e) => {
+      console.log(e);
+    };
+    const submenuChange = (e) => {
+      console.log(e);
+    };
+    return {
+      select,
+      deselect,
+      submenuChange,
+    };
+  },
+});
+</script>
 ```
 
 :::
 
-### dynamic argument
+### Only One Expansion
 
-For example, parameters such as 'width', 'open-keys', 'default-select-keys' can be modified dynamically
+:::demo Modify the ` ` ` open keys ` ` ` array through the submenu state change event to achieve the effect
+
+``` vue
+  <template>
+    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px">
+      <d-sub-menu title="submenu-1" key="submenu-1">
+        <template #icon>
+          <i class="icon-infomation"></i>
+        </template>
+        <d-menu-item key="subemenu-item-1">
+          <span>submenu-item-1</span>
+        </d-menu-item>
+      </d-sub-menu>
+      <d-sub-menu title="submenu-2" key="submenu-2">
+        <template #icon>
+          <i class="icon-setting"></i>
+        </template>
+        <d-menu-item key="submenu-item-2">
+          <span>submenu-item-2</span>
+        </d-menu-item>
+      </d-sub-menu>
+      <d-sub-menu title="submenu-3" key="submenu-3">
+        <template #icon>
+          <i class="icon-setting"></i>
+        </template>
+        <d-menu-item key="submenu-item-2">
+          <span>submenu-item-2</span>
+        </d-menu-item>
+      </d-sub-menu>
+    </d-menu>
+  </template>
+
+  <script>
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    setup() {
+      const openKeys = ref(['submenu-1']);
+      const submenuChange = (e) => {
+        console.log(e)
+        openKeys.value.forEach(element => {
+          openKeys.value.shift()
+        });
+        openKeys.value.push(e.key)
+      };
+      return {
+        openKeys,
+        submenuChange,
+      };
+    },
+  });
+  </script>
+```
+:::
+
+### Reactivity-Attribute
+
+eg. `width`, `open-keys`, `default-select-keys`
 
 :::demo
 
@@ -206,25 +295,25 @@ For example, parameters such as 'width', 'open-keys', 'default-select-keys' can 
       </template>
       <span>Home</span>
     </d-menu-item>
-    <d-sub-menu title="System">
+    <d-sub-menu title="System" key="icon-system">
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item>
+      <d-menu-item key="system">
         <span>System item</span>
       </d-menu-item>
-      <d-sub-menu title="Setting">
+      <d-sub-menu title="Setting" key="icon-setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item>
+        <d-menu-item key="setting">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
     </d-sub-menu>
   </d-menu>
   <br />
-  <d-slider :min="0" :max="480" v-model="width" tipsRenderer="px"></d-slider>
+  <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
 
 <script lang="ts" setup>
@@ -241,55 +330,58 @@ const changeDisabled = () => {
 
 :::
 
-### d-menu arguments
+### d-menu Attribute
 
-| argument            | type       | default value | introduce| Demo| global config |
-| --- | --- | --- | --- | --- | --- |
-| width               | String     | ''            | controller menu width                           | [dynamic argument](#dynamic argument) |               |
-| collapsed           | Boolean    | false         | controller menu collapsed status                | [collapse menu](#collapse menu)       |               |
-| collapsed-indent    | Number     | 24            | If menu is collapse icon sistance from the menu | /                                     |               |
-| indent-size         | indentSize | 24            | Not collapse sub menu indent size               | /                                     |               |
-| multiple            | Boolean    | false         | can multiple if is true                         | /                                     |               |
-| mode                | menuMode   | 'vertical'    | menu types                                      | [Basic Used](#Basic Used)             |               |
-| open-keys           | Array      | []            | default open sub menu's key                     | [default open](#default open)         |               |
-| default-select-keys | Array      | []            | default select menu item's key                  | /                                     |               |
+| Attribute                | Type                  | Default Value       | Description                                                                            | Demo                 |
+| ------------------- | --------------------- | ---------- | ------------------------------------------------------------------------------- | ------------------------- |
+| width               | String                | ''         | Used to control menu width                                                                | [Reactivity-Attribute](#Reactivity-Attribute) |
+| collapsed           | Boolean               | false      | Used to decide whether to collapse the menu                                                            | [Collapsed](#Collapsed)     |
+| collapsed-indent    | Number                | 24         | The distance between the starting icon and the left and right borders                                                    | [Collapsed](#Collapsed)     |
+| multiple            | Boolean               | false      | Can I select more than one                                                                    | [Deselect](#Deselect)     |
+| mode                | [menuMode](#menumode) | 'vertical' | menu type                                                                        | [Basic-Use](#Basic-Use)     |
+| open-keys           | Array                 | []         | default open key of menu item| [默认展开](#默认展开)     |
+| default-select-keys | Array                 | []         | default select key of menu item item                                                           | [Basic-Use](#Basic-Use)     |
+| router              | Boolean               | false      | Whether to enable 'Vue router' mode. Enabling this mode will jump the route with the key as the path when the navigation is activated | -                         |
 
-### d-menu event
+### d-menu Event
 
-| event| type|introduce| Demo |
-| :---: | :---: | :---: | :---: | :---: | :---: |
-| select         | `(e: {type:'select', el: HTMLElement})=>void`                          | select menu item will emit this event. if is disabled can't emit this event                      |
-| dselect        | `(e: {type: 'dselect', el: HTMLElement})=>void`                        | The event is triggered when unchecked, if the menu is not multi-select the menu is not triggered |      |
-| submenu-change | `(e: {type: 'submenu-change': el: HTMLElement: state: boolean})=>void` | Triggered when the submenu state is changed                                                      |
+| Event           | Type                                                                                | Description                                                 | Demo             |
+| -------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------- |
+| select         | `(e: {type: 'select', key: string, el: HTMLElement, e: PointerEvent})=>void`        | if select will trigger this event. if is disabled will not trigger        | [Deselect](#Deselect) |
+| deselect       | `(e: {type: 'deselect', key: string, el: HTMLElement, e: PointerEvent})=>void`      | This event will be triggered when deselecting. If the menu is not multi select, it will not be triggered | [Deselect](#Deselect) |
+| submenu-change | `(e: {type: 'submenu-change', state: boolean, key: string, el: HTMLElement})=>void` | Triggered when the submenu state is changed                             | [Deselect](#Deselect) |
 
-### d-menu-item arguments
+### d-menu-item
 
-| argument            | type       | default value | introduce| Demo| global config |
-| :---: | :---: | :---: | --- | --- | :---: |
-| disable | boolean | false |        Disabled this menu item.        |                       |            |
-|   key   | string  |  ''   |    menu item's key. Must is unique     |                       |            |
-|  href   | string  |  ''   | click menu item will link to page url. | [基本用法](#基本用法) |
+|   Attribute   |  Type   | Default Value  |          Description           |       Demo       |
+| :------: | :-----: | :---: | :---------------------: | :-------------------: |
+| disabled | boolean | false | disabled menu item         |           -           |
+|   key    | string  |  ''   | key of the menu item. Need to be unique |           -           |
+|   href   | string  |  ''   | Page to jump to after clicking the menu item  | [Basic-Use](#Basic-Use) |
+|  route   | object  |   -   |   Vue Router path object   |           -           |
 
-### d-sub-menu event
+### d-sub-menu
 
-| event| type|introduce| Demo |
-| :---: | :---: | :---: | :---: | :---: | :---: |
-|  title  | String  |  ''   | sub menu's title  |           |            |
-| disable | boolean | false | disabled sub menu |           |            |
+|   Attribute   |  Type   | Default Value  |      Description      |       Demo       |
+| :------: | :-----: | :---: | :------------: | :-------------------: |
+|  title   | String  |  ''   | sub-menu title   | [Basic-Use](#Basic-Use) |
+| disabled | boolean | false | disabled sub-menu |           -           |
 
 ### d-menu-item slot
 
-| slot name | description |
-| :---: | :--: |
-|icon|declare menu item icon|
+| 插槽名 |         Description          |
+| :----: | :-------------------: |
+|  icon  | used to define icon |
 
 ### d-sub-menu slot
 
-| slot name | description |
-| :---: |:---:|
-|icon|declare sub menu icon|
+| 插槽名 |           Description            |
+| :----: | :-----------------------: |
+|  icon  | used to define icon |
 
-### Interface & declare
+### menu type
+
+#### menuMode
 
 ```typescript
 export type menuMode = 'vertical' | 'horizontal';


### PR DESCRIPTION
- 修改范围： menu
- 修改内容如下
   - 增加文档
       - 仅展开一项（中/英）
   - 重构类名
   - `position: fixed` -> `position: absolute`
   - 修复了横向排列，尺寸过小时出现省略号，二级菜单无法显示问题