### PR TITLE
fix(checkbox): checkbox-button 追光主题下样式异常 (close #1015);

### DIFF
--- a/packages/devui-vue/devui/checkbox/src/checkbox-button.scss
+++ b/packages/devui-vue/devui/checkbox/src/checkbox-button.scss
@@ -38,7 +38,7 @@ $button-padding-map: (
     display: inline-block;
     line-height: 1;
     user-select: none;
-    box-shadow: -1px 0 0 0 #dfe1e6;
+    box-shadow: -1px 0 0 0 $devui-disabled-line;
     @each $size in ('lg', 'md', 'sm', 'xs') {
       &.#{$devui-prefix}-checkbox-button--#{$size} {
         font-size: map-get($font-size-map, #{$size});


### PR DESCRIPTION
checkbox-button 追光主题下样式异常，将颜色改为与边框一致的scss变量
<img width="516" alt="截屏2022-07-11 下午9 17 25" src="https://user-images.githubusercontent.com/52314078/178273087-0bcc4b61-9766-4277-86bd-21ffe4bf842d.png">
