### PR TITLE
fix(Cascader): 修复条件判断不严谨导致DOM渲染错误

### DIFF
--- a/packages/devui-vue/devui/cascader/components/cascader-item/index.tsx
+++ b/packages/devui-vue/devui/cascader/components/cascader-item/index.tsx
@@ -36,9 +36,11 @@ export const DCascaderItem = (props: CascaderItemPropsType): JSX.Element => {
     }
     updateValues();
   };
-  const mouseenter = isTriggerHover ? {
-    onMouseenter: mouseEnter,
-  } : {};
+  const mouseenter = isTriggerHover
+    ? {
+        onMouseenter: mouseEnter,
+      }
+    : {};
   // 鼠标click
   const mouseClick = () => {
     if (disbaled.value) {
@@ -75,11 +77,7 @@ export const DCascaderItem = (props: CascaderItemPropsType): JSX.Element => {
         <div class="dropdown-item-label">
           <span>{cascaderItem.label}</span>
         </div>
-        {
-          cascaderItem?.children?.length
-          && cascaderItem?.children?.length  > 0
-          && <Icon name="chevron-right" size="16px" color="inherit" />
-        }
+        {Boolean(cascaderItem?.children?.length) && <Icon name="chevron-right" size="16px" color="inherit" />}
       </div>
     </li>
   );


### PR DESCRIPTION
原写法`cascaderItem?.children?.length`会在`length=0`时，渲染`0`，并不会自动转为`false`。