### PR TITLE
refactor: 移除back-top和textarea组件中的无用api

### DIFF
--- a/packages/devui-vue/devui/back-top/src/back-top.tsx
+++ b/packages/devui-vue/devui/back-top/src/back-top.tsx
@@ -8,7 +8,6 @@ import './back-top.scss';
 export default defineComponent({
   name: 'DBackTop',
   props: backTopProps,
-  emits: ['click'],
   setup(props: BackTopProps, ctx) {
     const slots = ctx.slots;
     const backTopRef = ref(null);
@@ -24,7 +23,6 @@ export default defineComponent({
           left: 0,
           behavior: 'smooth', // 平滑滚动
         });
-      ctx.emit('click', e);
     };
 
     return () => (

--- a/packages/devui-vue/devui/textarea/src/composables/use-textarea-event.ts
+++ b/packages/devui-vue/devui/textarea/src/composables/use-textarea-event.ts
@@ -19,7 +19,6 @@ export function useTextareaEvent(isFocus: Ref<boolean>, props: TextareaProps, ct
 
   const onInput = (e: Event) => {
     ctx.emit('update:modelValue', (e.target as HTMLInputElement).value);
-    ctx.emit('update', (e.target as HTMLInputElement).value);
   };
 
   const onChange = (e: Event) => {

--- a/packages/devui-vue/devui/textarea/src/textarea.tsx
+++ b/packages/devui-vue/devui/textarea/src/textarea.tsx
@@ -11,7 +11,7 @@ export default defineComponent({
   name: 'DTextarea',
   inheritAttrs: false,
   props: textareaProps,
-  emits: ['update:modelValue', 'focus', 'blur', 'change', 'keydown', 'update'],
+  emits: ['update:modelValue', 'focus', 'blur', 'change', 'keydown'],
   setup(props: TextareaProps, ctx: SetupContext) {
     const { modelValue } = toRefs(props);
     const formItemContext = inject(FORM_ITEM_TOKEN, undefined) as FormItemContext;

--- a/packages/devui-vue/docs/components/back-top/index.md
+++ b/packages/devui-vue/docs/components/back-top/index.md
@@ -16,7 +16,7 @@
 <template>
   <div>
     <div>这里看不到我嘿嘿，下滑试试</div>
-    <d-back-top @click="handleClick" />
+    <d-back-top />
     <d-back-top bottom="100px">
       <d-icon name="chevron-up"></d-icon>
     </d-back-top>
@@ -28,12 +28,8 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   setup() {
-    const handleClick = (e: MouseEvent) => {
-      console.log('backTop', e);
-    };
     return {
       msg: 'BackTop 回到顶部 组件文档示例',
-      handleClick,
     };
   },
 });
@@ -146,9 +142,3 @@ d-back-top 参数
 | visibleHeight | `number` |   300    | 可选，滚动高度达到 visibleHeight 所设值后展示回到顶部按钮，单位为`px` |   [示例](#基本用法)   |
 |    target     | `string` | 'window' |                      可选，触发滚动的元素选择器                       | [示例](#嵌入容器内部) |
 |               |          |          |                                                                       |                       |
-
-d-back-top 事件
-
-| 事件名 | 回调参数                  | 说明                 |
-| :----- | :------------------------ | :------------------- |
-| click  | `Function(e: MouseEvent)` | 点击回到顶部按钮触发 |

--- a/packages/devui-vue/docs/components/textarea/index.md
+++ b/packages/devui-vue/docs/components/textarea/index.md
@@ -169,7 +169,6 @@ export default defineComponent({
     show-count
     :max-length="20"
     placeholder="打开控制台输入文字看看"
-    @update="onUpdate"
     @update:modelValue="onUpdate"
     @change="onChange"
     @focus="onFocus"
@@ -183,7 +182,6 @@ export default {
   setup() {
     const onUpdate = (value) => {
       console.log('【d-textarea update value】：', value);
-      console.log('【d-textarea update】：', value);
     };
     const onChange = (value) => {
       console.log('【d-textarea change value】：', value);


### PR DESCRIPTION
- back-top 组件中的 click 就是原生容器的 click 事件，无必要添加
- textarea 组件中的 update 事件与 update:modelValue 事件重复，无必要添加