### PR TITLE
chore: add pull request preview github action

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,43 @@
+name: Preview Build
+
+on:
+  pull_request:
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - name: Run Npm Scripts
+        run: |
+          node -v
+          npm install pnpm -g
+          pnpm -v
+          pnpm i
+          pnpm build
+      - run: |
+          zip -r dist.zip ./packages/devui-vue/docs/.vitepress/dist
+      - name: upload dist artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist.zip
+          retention-days: 5
+
+      - name: Save PR number
+        if: ${{ always() }}
+        run: echo ${{ github.event.number }} > ./pr-id.txt
+
+      - name: Upload PR number
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr
+          path: ./pr-id.txt

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,67 @@
+name: Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ['Preview Build']
+    types:
+      - completed
+
+jobs:
+  success:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: download pr artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pr
+      - name: save PR id
+        id: pr
+        run: echo "::set-output name=id::$(<pr-id.txt)"
+      - name: download dist artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          name: dist
+      - run: |
+          unzip dist.zip
+      - name: upload to surge
+        id: deploy
+        run: |
+          export DEPLOY_DOMAIN=https://vue-devui-pr-${{ steps.pr.outputs.id }}.surge.sh
+          npx surge --project packages/devui-vue/docs/.vitepress/dist/ --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+      - name: create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ steps.pr.outputs.id }}
+          body: |
+            PR preview has been successfully built and deployed to https://vue-devui-pr-${{ steps.pr.outputs.id }}.surge.sh.
+      - run: |
+          rm -rf packages/devui-vue/docs/.vitepress/dist
+      - name: The job failed
+        if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ steps.pr.outputs.id }}
+          body: |
+            Deploy PR preview failed.
+  failed:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: download pr artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pr
+      - name: save PR id
+        id: pr
+        run: echo "::set-output name=id::$(<pr-id.txt)"
+      - name: The job failed
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ steps.pr.outputs.id }}
+          body: |
+            Deploy PR preview failed.


### PR DESCRIPTION
## 增加PR预览站点
给PR/review 增加更好的体验，本次pr的ci会给每次的pr生成预览站点。
预览域名为：https://vue-devui-pr-${{ prId }}.surge.sh
如下图
<img width="805" alt="image" src="https://user-images.githubusercontent.com/33956589/180633042-71114850-6c3d-40bb-8b60-2991e810cad5.png">

## 配置方法
> ref: https://surge.sh/
```bash
npx surge token
```
输入邮箱跟密码即可生成token，token填入GitHub仓库的token里面，如下图。token的key为`SURGE_TOKEN`,value为上面生成的token。
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/33956589/180633166-a78b522c-47a2-4285-a5c6-454e1834c15a.png">

