### PR TITLE
fix(Carousel): 解决指示器样式和自动轮播问题

### DIFF
--- a/packages/devui-theme/src/theme/theme-data.ts
+++ b/packages/devui-theme/src/theme/theme-data.ts
@@ -42,9 +42,9 @@ export const devuiLightTheme: Theme = new Theme({
     // 图标
     'devui-icon-text': '#252b3a',
     'devui-icon-bg': '#ffffff',
-    'devui-icon-fill': '#8a8e99',
-    'devui-icon-fill-hover': '#5e7ce0',
-    'devui-icon-fill-active': '#5e7ce0',
+    'devui-icon-fill': '#71757f',
+    'devui-icon-fill-hover': '#252b3a',
+    'devui-icon-fill-active': '#252b3a',
     'devui-icon-fill-active-hover': '#526ecc',
     // 表单
     'devui-form-control-line': '#adb0b8',

--- a/packages/devui-vue/devui/carousel/__tests__/carousel.spec.ts
+++ b/packages/devui-vue/devui/carousel/__tests__/carousel.spec.ts
@@ -82,7 +82,7 @@ describe('d-carousel', () => {
         'd-carousel-item': CarouselItem,
       },
       template: `
-        <d-carousel ref="carousel" height="200px" :activeIndexChange="onChange">
+        <d-carousel ref="carousel" height="200px" @activeIndexChange="onChange">
           <d-carousel-item>Page 1</d-carousel-item>
           <d-carousel-item>Page 2</d-carousel-item>
           <d-carousel-item>Page 3</d-carousel-item>
@@ -116,7 +116,7 @@ describe('d-carousel', () => {
         'd-carousel-item': CarouselItem,
       },
       template: `
-        <d-carousel ref="carousel" height="200px" :activeIndexChange="onChange" dotTrigger="hover">
+        <d-carousel ref="carousel" height="200px" @activeIndexChange="onChange" dotTrigger="hover">
           <d-carousel-item>Page 1</d-carousel-item>
           <d-carousel-item>Page 2</d-carousel-item>
           <d-carousel-item>Page 3</d-carousel-item>
@@ -150,7 +150,7 @@ describe('d-carousel', () => {
         'd-button': Button,
       },
       template: `
-        <d-carousel ref="carousel" height="200px" arrowTrigger="always" :activeIndexChange="onChange">
+        <d-carousel ref="carousel" height="200px" arrowTrigger="always" @activeIndexChange="onChange">
           <d-carousel-item v-for="item in items" :key="item">{{ item }} </d-carousel-item>
         </d-carousel>
         <div class="carousel-demo-operate">
@@ -221,7 +221,7 @@ describe('d-carousel', () => {
         'd-carousel-item': CarouselItem,
       },
       template: `
-        <d-carousel ref="carousel" height="200px" :activeIndexChange="onChange" autoplay :autoplaySpeed="2000">
+        <d-carousel ref="carousel" height="200px" @activeIndexChange="onChange" autoplay :autoplaySpeed="2000">
           <d-carousel-item>Page 1</d-carousel-item>
           <d-carousel-item>Page 2</d-carousel-item>
           <d-carousel-item>Page 3</d-carousel-item>

--- a/packages/devui-vue/devui/carousel/src/carousel.scss
+++ b/packages/devui-vue/devui/carousel/src/carousel.scss
@@ -87,12 +87,12 @@
 
       &:hover {
         cursor: pointer;
-        background: $devui-list-item-hover-bg;
+        background: $devui-icon-fill-hover;
       }
 
       &.active {
         width: 24px;
-        background: $devui-list-item-active-bg;
+        background: $devui-icon-fill-active;
         transition: all $devui-animation-duration-slow $devui-animation-ease-in-smooth;
       }
     }

--- a/packages/devui-vue/devui/carousel/src/types.ts
+++ b/packages/devui-vue/devui/carousel/src/types.ts
@@ -7,7 +7,7 @@ export type DotPosition = 'bottom' | 'top';
 export const carouselProps = {
   arrowTrigger: {
     type: String as PropType<ArrowTrigger>,
-    default: 'hover'
+    default: 'hover',
   },
   autoplay: {
     type: Boolean,
@@ -15,7 +15,7 @@ export const carouselProps = {
   },
   autoplaySpeed: {
     type: Number,
-    default: 3000
+    default: 3000,
   },
   height: {
     type: String,
@@ -23,7 +23,7 @@ export const carouselProps = {
   },
   showDots: {
     type: Boolean,
-    default: true
+    default: true,
   },
   dotTrigger: {
     type: String as PropType<DotTrigger>,
@@ -35,12 +35,8 @@ export const carouselProps = {
   },
   activeIndex: {
     type: Number,
-    default: 0
-  },
-  activeIndexChange: {
-    type: Function as unknown as () => ((index: number) => void)
+    default: 0,
   },
 } as const;
-
 
 export type CarouselProps = ExtractPropTypes<typeof carouselProps>;

--- a/packages/devui-vue/docs/components/carousel/index.md
+++ b/packages/devui-vue/docs/components/carousel/index.md
@@ -47,7 +47,7 @@ arrowTrigger 设为 always 可以使箭头永久显示，dotTrigger 设为 hover
 
 ```vue
 <template>
-  <d-carousel height="200px" arrowTrigger="always" dotTrigger="hover">
+  <d-carousel height="200px" arrowTrigger="always" dot-trigger="hover">
     <d-carousel-item class="d-carousel-item" v-for="item in items" :key="item">{{ item }}</d-carousel-item>
   </d-carousel>
 </template>
@@ -80,7 +80,7 @@ export default defineComponent({
 
 ```vue
 <template>
-  <d-carousel height="200px" autoplay :autoplaySpeed="3000">
+  <d-carousel height="200px" autoplay :autoplay-speed="3000">
     <d-carousel-item class="d-carousel-item" v-for="item in items" :key="item">{{ item }}</d-carousel-item>
   </d-carousel>
 </template>
@@ -164,27 +164,27 @@ export default defineComponent({
 
 ### Carousel 参数
 
-|     参数      |             类型             |  默认值  | 描述                                                               | 跳转 Demo                           |
-| :-----------: | :--------------------------: | :------: | :----------------------------------------------------------------- | ----------------------------------- |
-| arrowTrigger  | `'hover'\|'never'\|'always'` | 'hover'  | 可选，指定切换箭头显示方式                                         | [指示器&切换箭头](#指示器-切换箭头) |
-|   autoplay    |          `boolean`           |  false   | 可选，是否自动轮播                                                 | [自动轮播](#自动轮播)               |
-| autoplaySpeed |           `number`           |   3000   | 可选，配合`autoplay`使用，自动轮播速度，单位 ms                    | [自动轮播](#自动轮播)               |
-|    height     |           `string`           |  '100%'  | 可选，轮播容器高度                                                 | [基本用法](#基本用法)               |
-|   showDots    |          `boolean`           |   true   | 可选，是否显示面板指示器                                           | [自动轮播](#自动轮播)               |
-|  dotPosition  |      `'top'\|'bottom'`       | 'bottom' | 可选，面板指示器位置                                               | [指示器&切换箭头](#指示器-切换箭头) |
-|  dotTrigger   |      `'click'\|'hover'`      | 'click'  | 可选，指示器触发轮播方式                                           | [指示器&切换箭头](#指示器-切换箭头) |
-|  activeIndex  |           `number`           |    0     | 可选，初始化激活卡片索引，从 0 开始，支持`[(activeIndex)]`双向绑定 | [基本用法](#基本用法)               |
+| 参数           | 类型                         | 默认值   | 描述                                                                | 跳转 Demo                           |
+| :------------- | :--------------------------- | :------- | :------------------------------------------------------------------ | ----------------------------------- |
+| arrow-trigger  | `'hover'\|'never'\|'always'` | 'hover'  | 可选，指定切换箭头显示方式                                          | [指示器&切换箭头](#指示器-切换箭头) |
+| autoplay       | `boolean`                    | false    | 可选，是否自动轮播                                                  | [自动轮播](#自动轮播)               |
+| autoplay-speed | `number`                     | 3000     | 可选，配合`autoplay`使用，自动轮播速度，单位 ms                     | [自动轮播](#自动轮播)               |
+| height         | `string`                     | '100%'   | 可选，轮播容器高度                                                  | [基本用法](#基本用法)               |
+| show-dots      | `boolean`                    | true     | 可选，是否显示面板指示器                                            | [自动轮播](#自动轮播)               |
+| dot-position   | `'top'\|'bottom'`            | 'bottom' | 可选，面板指示器位置                                                | [指示器&切换箭头](#指示器-切换箭头) |
+| dot-trigger    | `'click'\|'hover'`           | 'click'  | 可选，指示器触发轮播方式                                            | [指示器&切换箭头](#指示器-切换箭头) |
+| active-index   | `number`                     | 0        | 可选，初始化激活卡片索引，从 0 开始，支持`[(active-index)]`双向绑定 | [基本用法](#基本用法)               |
 
 ### Carousel 事件
 
-|       事件        |          类型          |                   描述                    | 跳转 Demo             |
-| :---------------: | :--------------------: | :---------------------------------------: | --------------------- |
-| activeIndexChange | `EventEmitter<number>` | 卡片切换时，返回当前卡片的索引，从 0 开始 | [基本用法](#基本用法) |
+| 事件                | 类型                   | 描述                                      | 跳转 Demo             |
+| :------------------ | :--------------------- | :---------------------------------------- | --------------------- |
+| active-index-change | `EventEmitter<number>` | 卡片切换时，返回当前卡片的索引，从 0 开始 | [基本用法](#基本用法) |
 
 ### Carousel 方法
 
-|    方法     | 描述                                | 跳转 Demo                 |
-| :---------: | :---------------------------------- | :------------------------ |
-|   prev()    | 切换到上一张卡片                    | [自定义操作](#自定义操作) |
-|   next()    | 切换到下一张卡片                    | [自定义操作](#自定义操作) |
+| 方法        | 描述                                | 跳转 Demo                 |
+| :---------- | :---------------------------------- | :------------------------ |
+| prev()      | 切换到上一张卡片                    | [自定义操作](#自定义操作) |
+| next()      | 切换到下一张卡片                    | [自定义操作](#自定义操作) |
 | goTo(index) | 切换到指定索引的卡片，索引从 0 开始 | [自定义操作](#自定义操作) |


### PR DESCRIPTION
1、解决指示器无限主题颜色错误问题
2、解决`autoplay`为`false`时，仍自动轮播的问题
3、代码格式化调整，`render`函数移到`setup`中
4、`activeIndexChange`事件应该用`emit`触发，而不是通过`props`设置
5、文档格式化调整，参数和事件采用中划线风格