### PR TITLE
fix(DatePickerPro): 修复 DatePickerPro 测试用例因日期格式不同导致的测试用例执行失败

### DIFF
--- a/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
@@ -346,7 +346,6 @@ describe('date-picker-pro test', () => {
 
     const button = rightArea.find('button');
     expect(button.exists()).toBeTruthy();
-    const date = new Date();
     await button.trigger('click');
 
     await nextTick();

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
@@ -352,12 +352,7 @@ describe('date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const inputNew = vm.$el.querySelector('input');
-    const newDate = new Date(date.getTime() - 30 * 24 * 3600 * 1000);
-    expect(inputNew.value).toBe(
-      `${newDate.getFullYear()}/${
-        newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1
-      }/${newDate.getDate()}`
-    );
+    expect(inputNew.value).toBe(dayjs().subtract(30, 'day').format('YYYY/MM/DD'));
 
     wrapper.unmount();
   });
@@ -404,12 +399,7 @@ describe('date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const inputNew = vm.$el.querySelector('input');
-    const newDate = new Date();
-    expect(inputNew.value).toBe(
-      `${newDate.getFullYear()}/${
-        newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1
-      }/${newDate.getDate()}`
-    );
+    expect(inputNew.value).toBe(dayjs().format('YYYY/MM/DD'));
 
     wrapper.unmount();
   });

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import dayjs from 'dayjs';
 import DRangeDatePickerPro from '../src/components/range-date-picker-pro';
 import { nextTick, ref, getCurrentInstance } from 'vue';
 import { useNamespace } from '../../shared/hooks/use-namespace';
@@ -307,14 +308,13 @@ describe('range-date-picker-pro test', () => {
     const vm = wrapper.vm;
     const inputNews = vm.$el.querySelectorAll('input');
     expect(inputNews.length).toBe(2);
-    const newDate = new Date(date.getTime() - 30 * 24 * 3600 * 1000);
+
     expect(inputNews[0].value).toBe(
-      `${newDate.getFullYear()}/${
-        newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1
-      }/${newDate.getDate()}`
+      dayjs().subtract(30, 'day').format('YYYY/MM/DD'),
     );
+
     expect(inputNews[1].value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`
+      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`,
     );
 
     wrapper.unmount();
@@ -362,15 +362,10 @@ describe('range-date-picker-pro test', () => {
     const vm = wrapper.vm;
     const inputNews = vm.$el.querySelectorAll('input');
     expect(inputNews.length).toBe(2);
-    const newDate = new Date(date.getTime() + 1 * 24 * 3600 * 1000);
-    expect(inputNews[0].value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`
-    );
-    expect(inputNews[1].value).toBe(
-      `${newDate.getFullYear()}/${
-        newDate.getMonth() + 1 < 10 ? '0' + (newDate.getMonth() + 1) : newDate.getMonth() + 1
-      }/${newDate.getDate()}`
-    );
+
+    expect(inputNews[0].value).toBe(dayjs().format('YYYY/MM/DD'),);
+
+    expect(inputNews[1].value).toBe(dayjs().add(1, 'day').format('YYYY/MM/DD'));
 
     wrapper.unmount();
   });

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
@@ -355,7 +355,6 @@ describe('range-date-picker-pro test', () => {
 
     const button = footer.find('button');
     expect(button.exists()).toBeTruthy();
-    const date = new Date();
     await button.trigger('click');
 
     await nextTick();


### PR DESCRIPTION
修复 DatePickerPro 测试用例因日期格式不同导致的测试用例执行失
<img width="1164" alt="截屏2022-07-31 下午1 33 42" src="https://user-images.githubusercontent.com/52314078/182011787-664360a4-b16c-4845-8230-4621008545ae.png">
败