### PR TITLE
fix(tree): 修复名称修改带来的错误

### DIFF
--- a/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
@@ -346,7 +346,6 @@ describe('date-picker-pro test', () => {
 
     const button = rightArea.find('button');
     expect(button.exists()).toBeTruthy();
-    const date = new Date();
     await button.trigger('click');
 
     await nextTick();

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
@@ -355,7 +355,6 @@ describe('range-date-picker-pro test', () => {
 
     const button = footer.find('button');
     expect(button.exists()).toBeTruthy();
-    const date = new Date();
     await button.trigger('click');
 
     await nextTick();

--- a/packages/devui-vue/devui/tree/src/components/tree-node.tsx
+++ b/packages/devui-vue/devui/tree/src/components/tree-node.tsx
@@ -83,7 +83,7 @@ export default defineComponent({
       let dragdropProps = {};
       if (dragdrop.value && !data.value?.disableSelect) {
         dragdropProps = {
-          dragdrop: true,
+          draggable: true,
           onDragstart: (event: DragEvent) => onDragstart?.(event, data.value),
           onDragover: (event: DragEvent) => onDragover?.(event),
           onDragleave: (event: DragEvent) => onDragleave?.(event),

--- a/packages/devui-vue/docs/components/tree/index.md
+++ b/packages/devui-vue/docs/components/tree/index.md
@@ -769,14 +769,14 @@ export default defineComponent({
 
 ### 可拖拽树
 
-:::demo 通过OperableTree的 draggable 属性配置节点的拖拽功能，并支持外部元素拖拽入树。
+:::demo 通过OperableTree的 dragdrop 属性配置节点的拖拽功能，并支持外部元素拖拽入树。
 
 ```vue
 <template>
   <h6><p>Default</p></h6>
-  <d-tree :data="data" draggable ></d-tree>
+  <d-tree :data="data" dragdrop ></d-tree>
   <h6><p>Sortable</p></h6>
-  <d-tree :data="data" :draggable="{ dropPrev: true, dropNext: true, dropInner: true }"></d-tree>
+  <d-tree :data="data" :dragdrop="{ dropPrev: true, dropNext: true, dropInner: true }"></d-tree>
 </template>
 
 <script>


### PR DESCRIPTION
1. 组件拖拽功能应该使用`draggable: true`, 而不是`dragdrop: true`
2. 增加 `onDragend` 事件, 在结束之后清除拖拽，以解决不同组件拖拽会焦距的问题。（`onDrop`在拖拽到有效目标且释放之后会触发、`onDragend`会在拖拽结束之后执行）