### PR TITLE
fix(date-picker-pro): 解决DatePickerPro组件的单元测试报错

### DIFF
--- a/packages/devui-vue/devui/date-picker-pro/__tests__/const.ts
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/const.ts
@@ -1,0 +1,3 @@
+export const DATE_FORMAT = 'YYYY/MM/DD';
+
+export const TIME_FORMAT = `${DATE_FORMAT} hh:mm:ss`;

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
@@ -5,6 +5,8 @@ import { nextTick, ref, getCurrentInstance } from 'vue';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 import DButton from '../../button/src/button';
 import { Locale } from '../../locale';
+import { getDateIndex, getSelectedDate, getSelectedIndex } from './utils';
+import { DATE_FORMAT, TIME_FORMAT } from './const';
 
 const ns = useNamespace('date-picker-pro', true);
 const baseClass = ns.b();
@@ -76,15 +78,14 @@ describe('date-picker-pro test', () => {
     const tableMonthItems = pickerPanel.findAll(tableMonthClass);
 
     const date = new Date();
-    const todayIndex = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
-    const selectIndex = todayIndex > 20 ? todayIndex - 1 : todayIndex + 1;
+    const todayIndex = getDateIndex(date);
+
+    const selectIndex = getSelectedIndex(todayIndex);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(ns.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
     await Items[selectIndex].trigger('click');
-    expect(dayjs(datePickerProValue.value).format('YYYY/M/D')).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1}/${todayIndex > 20 ? date.getDate() - 1 : date.getDate() + 1}`
-    );
+    expect(dayjs(datePickerProValue.value).format(DATE_FORMAT)).toBe(getSelectedDate(todayIndex, date));
 
     const pickerPanelNew = container.find(pickerPanelClass);
     expect(pickerPanelNew.exists()).toBeFalsy();
@@ -113,7 +114,7 @@ describe('date-picker-pro test', () => {
     const tableMonthItems = pickerPanel.findAll(tableMonthClass);
 
     const date = new Date();
-    const selectIndex = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
+    const selectIndex = getDateIndex(date);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(ns.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
@@ -142,19 +143,15 @@ describe('date-picker-pro test', () => {
     const tableMonthItems = pickerPanel.findAll(tableMonthClass);
 
     const date = new Date();
-    const todayIndex = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
-    const selectIndex = todayIndex > 20 ? todayIndex - 1 : todayIndex + 1;
+    const todayIndex = getDateIndex(date);
+    const selectIndex = getSelectedIndex(todayIndex);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(ns.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
     await Items[selectIndex].trigger('click');
     const vm = wrapper.vm;
     const inputNew = vm.$el.querySelector('input');
-    expect(inputNew.value).toBe(
-      `${date.getFullYear()}-${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}-${
-        todayIndex > 20 ? date.getDate() - 1 : date.getDate() + 1
-      }`
-    );
+    expect(dayjs(inputNew.value).format(DATE_FORMAT)).toBe(getSelectedDate(todayIndex, date));
 
     wrapper.unmount();
   });
@@ -186,20 +183,20 @@ describe('date-picker-pro test', () => {
     expect(timeUl[2].element.childElementCount).toBe(60);
 
     const date = new Date();
-    const todayIndex = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
-    const selectIndex = todayIndex > 20 ? todayIndex - 1 : todayIndex + 1;
+    const todayIndex = getDateIndex(date);
+    const selectIndex = getSelectedIndex(todayIndex);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(ns.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
     await Items[selectIndex].trigger('click');
-    expect(dayjs(datePickerProValue.value).format('YYYY/M/D hh:mm:ss')).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1}/${todayIndex > 20 ? date.getDate() - 1 : date.getDate() + 1} 12:00:00`
+    expect(dayjs(datePickerProValue.value).format(TIME_FORMAT)).toBe(
+      `${getSelectedDate(todayIndex, date)} 12:00:00`
     );
 
     const liItems = timeUl[0].findAll('.time-li');
     await liItems[3].trigger('click');
-    expect(dayjs(datePickerProValue.value).format('YYYY/M/D hh:mm:ss')).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1}/${todayIndex > 20 ? date.getDate() - 1 : date.getDate() + 1} 03:00:00`
+    expect(dayjs(datePickerProValue.value).format(TIME_FORMAT)).toBe(
+      `${getSelectedDate(todayIndex, date)} 03:00:00`
     );
 
     const pickerPanelFooter = container.find(ns.e('panel-footer'));
@@ -272,9 +269,7 @@ describe('date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const input = vm.$el.querySelector('input');
-    expect(input.value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`
-    );
+    expect(input.value).toBe(dayjs(date).format(DATE_FORMAT));
     const singlePicker = container.find(ns.e('single-picker'));
     await singlePicker.trigger('mouseover');
     const icon = singlePicker.find(ns.m('icon-visible'));
@@ -351,7 +346,7 @@ describe('date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const inputNew = vm.$el.querySelector('input');
-    expect(inputNew.value).toBe(dayjs().subtract(30, 'day').format('YYYY/MM/DD'));
+    expect(inputNew.value).toBe(dayjs().subtract(30, 'day').format(DATE_FORMAT));
 
     wrapper.unmount();
   });
@@ -398,7 +393,7 @@ describe('date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const inputNew = vm.$el.querySelector('input');
-    expect(inputNew.value).toBe(dayjs().format('YYYY/MM/DD'));
+    expect(inputNew.value).toBe(dayjs().format(DATE_FORMAT));
 
     wrapper.unmount();
   });

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
@@ -5,6 +5,8 @@ import { nextTick, ref, getCurrentInstance } from 'vue';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 import DButton from '../../button/src/button';
 import { Locale } from '../../locale';
+import { getDateIndex, getSelectedDate, getSelectedIndex } from './utils';
+import { DATE_FORMAT } from './const';
 
 const datePickerNs = useNamespace('date-picker-pro', true);
 const rangeDatePickerNs = useNamespace('range-date-picker-pro', true);
@@ -85,28 +87,22 @@ describe('range-date-picker-pro test', () => {
     const tableMonthItems = pickerPanel.findAll(tableMonthClass);
 
     const date = new Date();
-    const todayIndex = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
-    const selectIndex = todayIndex > 20 ? todayIndex : todayIndex + 1;
+    const todayIndex = getDateIndex(date);
+    const selectIndex = getSelectedIndex(todayIndex);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(datePickerNs.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
     await Items[selectIndex].trigger('click');
     await nextTick();
-    expect(inputs[0].element.value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${
-        todayIndex > 20 ? date.getDate() : date.getDate() + 1
-      }`
-    );
+
+    expect(dayjs(inputs[0].element.value).format(DATE_FORMAT)).toBe(getSelectedDate(todayIndex, date));
     expect(inputs[1].element.value).toBe('');
 
-    const newSelectIndex = todayIndex > 20 ? todayIndex : todayIndex + 5;
+    const newSelectIndex = getSelectedIndex(todayIndex, 5);
     await Items[newSelectIndex].trigger('click');
     await nextTick();
-    expect(inputs[0].element.value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${
-        todayIndex > 20 ? date.getDate() : date.getDate() + 1
-      }`
-    );
+    expect(dayjs(inputs[0].element.value).format(DATE_FORMAT)).toBe(getSelectedDate(todayIndex, date, 5));
+
     // todo 选择第二个日期时，focusType判断仍然是start。 demo中是正确的，单测原因需进一步确定
     // expect(inputs[1].element.value).toBe(
     //   `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${
@@ -141,8 +137,8 @@ describe('range-date-picker-pro test', () => {
     const tableMonthItems = pickerPanel.findAll(tableMonthClass);
 
     const date = new Date();
-    const todayIndx = 7 - ((date.getDate() - date.getDay()) % 7) + date.getDate();
-    const selectIndex = date.getDate() > 20 ? todayIndx : todayIndx + 5;
+    const todayIndx = getDateIndex(date);
+    const selectIndex = getSelectedIndex(todayIndx, 5);
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems[1].find(datePickerNs.e('table-month-content'));
     const Items = monthContentContainer.findAll('td');
@@ -223,9 +219,7 @@ describe('range-date-picker-pro test', () => {
     await nextTick();
     const vm = wrapper.vm;
     const inputs = vm.$el.querySelectorAll('input');
-    expect(inputs[0].value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`
-    );
+    expect(inputs[0].value).toBe(dayjs(date).format(DATE_FORMAT));
     expect(inputs[1].value).toBe('');
 
     const rangePicker = container.find(rangeDatePickerNs.e('range-picker'));
@@ -310,12 +304,10 @@ describe('range-date-picker-pro test', () => {
     expect(inputNews.length).toBe(2);
 
     expect(inputNews[0].value).toBe(
-      dayjs().subtract(30, 'day').format('YYYY/MM/DD'),
+      dayjs().subtract(30, 'day').format(DATE_FORMAT),
     );
 
-    expect(inputNews[1].value).toBe(
-      `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`,
-    );
+    expect(inputNews[1].value).toBe(dayjs(date).format(DATE_FORMAT));
 
     wrapper.unmount();
   });
@@ -362,9 +354,9 @@ describe('range-date-picker-pro test', () => {
     const inputNews = vm.$el.querySelectorAll('input');
     expect(inputNews.length).toBe(2);
 
-    expect(inputNews[0].value).toBe(dayjs().format('YYYY/MM/DD'),);
+    expect(inputNews[0].value).toBe(dayjs().format(DATE_FORMAT),);
 
-    expect(inputNews[1].value).toBe(dayjs().add(1, 'day').format('YYYY/MM/DD'));
+    expect(inputNews[1].value).toBe(dayjs().add(1, 'day').format(DATE_FORMAT));
 
     wrapper.unmount();
   });

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/utils.ts
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/utils.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import { DATE_FORMAT } from './const';
+
+export const getDateIndex = (date: Date): number => {
+  return dayjs(date).subtract(date.getDate() - 1, 'day').day() + date.getDate() - 1;
+};
+
+export const getSelectedIndex = (todayIndex: number, intervalDay = 1): number => {
+  return todayIndex > 20 ? todayIndex - 1 : todayIndex + intervalDay;
+};
+
+export const getSelectedDate = (todayIndex: number, date: Date, intervalDay = 1): string => {
+  return todayIndex > 20 ? dayjs(date).subtract(1, 'day').format(DATE_FORMAT) : dayjs(date).add(intervalDay, 'day').format(DATE_FORMAT);
+};


### PR DESCRIPTION
解决以下单元测试报错：

```
Summary of all failing tests
FAIL devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx
  ● date-picker-pro test › date-picker-pro select date

    expect(received).toBe(expected) // Object.is equality

    Expected: "2022/8/2"
    Received: "2022/8/9"

      83 |     const Items = monthContentContainer.findAll('td');
      84 |     await Items[selectIndex].trigger('click');
    > 85 |     expect(dayjs(datePickerProValue.value).format('YYYY/M/D')).toBe(
         |                                                                ^
      86 |       `${date.getFullYear()}/${date.getMonth() + 1}/${todayIndex > 20 ? date.getDate() - 1 : date.getDate() + 1}`
      87 |     );
      88 |

      at Object.<anonymous> (devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx:85:64)

  ● date-picker-pro test › date-picker-pro v-model test

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      118 |     const monthContentContainer = tableMonthItems[1].find(ns.e('table-month-content'));
      119 |     const Items = monthContentContainer.findAll('td');
    > 120 |     expect(Items[selectIndex].classes().includes(noDotNs.e('table-date-selected'))).toBe(true);
          |                                                                                     ^
      121 |
      122 |     wrapper.unmount();
      123 |   });

      at Object.<anonymous> (devui/date-picker-pro/__tests__/date-picker-pro.spec.tsx:120:85)

  ● date-picker-pro test › date-picker-pro format props

    expect(received).toBe(expected) // Object.is equality

    Expected: "2022-08-2"
    Received: "2022-08-09"

      151 |     const vm = wrapper.vm;
      152 |     const inputNew = vm.$el.querySelector('input');
      93 |     await Items[selectIndex].trigger('click');
      94 |     await nextTick();
    > 95 |     expect(inputs[0].element.value).toBe(
         |                                     ^
      96 |       `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${
      97 |         todayIndex > 20 ? date.getDate() : date.getDate() + 1
      98 |       }`

      at Object.<anonymous> (devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx:95:37)

  ● range-date-picker-pro test › date-picker-pro v-model test

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      147 |     const monthContentContainer = tableMonthItems[1].find(datePickerNs.e('table-month-content'));
      148 |     const Items = monthContentContainer.findAll('td');
    > 149 |     expect(Items[todayIndx].classes().includes(noDotDatePickerNs.e('table-date-start'))).toBe(true);
          |                                                                                          ^
      150 |
      151 |     await inputs[1].trigger('focus');
      152 |     await nextTick();

      at Object.<anonymous> (devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx:149:90)

  ● range-date-picker-pro test › range-date-picker-pro clear date

    expect(received).toBe(expected) // Object.is equality

    Expected: "2022/08/1"
    Received: "2022/08/01"

      224 |     const vm = wrapper.vm;
      225 |     const inputs = vm.$el.querySelectorAll('input');
    > 226 |     expect(inputs[0].value).toBe(
          |                             ^
      227 |       `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`
      228 |     );
      229 |     expect(inputs[1].value).toBe('');

      at Object.<anonymous> (devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx:226:29)

  ● range-date-picker-pro test › range-date-picker-pro rightArea slot

    expect(received).toBe(expected) // Object.is equality

    Expected: "2022/08/1"
    Received: "2022/08/01"

      314 |     );
      315 |
    > 316 |     expect(inputNews[1].value).toBe(
          |                                ^
      317 |       `${date.getFullYear()}/${date.getMonth() + 1 < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}/${date.getDate()}`,
      318 |     );
      319 |

      at Object.<anonymous> (devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx:316:32)


Test Suites: 2 failed, 85 passed, 87 total
Tests:       9 failed, 1 todo, 507 passed, 517 total
Snapshots:   1 passed, 1 total
```