### PR TITLE
chore: fix vitepress head type

### DIFF
--- a/packages/devui-vue/docs/.vitepress/config/head.ts
+++ b/packages/devui-vue/docs/.vitepress/config/head.ts
@@ -1,5 +1,5 @@
-const head = [
-  ['link', { rel: 'icon', type: 'image/svg+xml', href: '/assets/logo.svg' }],
-]
+import { HeadConfig } from 'vitepress';
 
-export default head
+const head: HeadConfig[] = [['link', { rel: 'icon', type: 'image/svg+xml', href: '/assets/logo.svg' }]];
+
+export default head;


### PR DESCRIPTION
给 vitepress 的head配置加上类型