### PR TITLE
fix(Table): #1083 修复table中loadingMask无法全覆盖table的问题

### DIFF
--- a/packages/devui-theme/src/styles-var/private/_z-index.scss
+++ b/packages/devui-theme/src/styles-var/private/_z-index.scss
@@ -8,5 +8,6 @@ $devui-z-index-drawer: var(--devui-z-index-drawer, 1040);// 抽屉板
 $devui-z-index-framework: var(--devui-z-index-framework, 1000);// 框架类元素，header,sideMenu等
 
 // 内容层，根据需要设置，zIndex需小于临时层
+$devui-z-index-function-widget: var(--devui-z-index-function-widget, 999); // 功能控件类（在一个组件中处于最上层）
 
 // 背景层，根据需要设置，zIndex需小于内容层

--- a/packages/devui-vue/devui/color-picker/src/color-picker.scss
+++ b/packages/devui-vue/devui/color-picker/src/color-picker.scss
@@ -5,7 +5,7 @@
 
   &-position {
     position: absolute;
-    z-index: 9999;
+    z-index: $devui-z-index-function-widget;
     background-color: $devui-connected-overlay-bg;
     top: 0;
   }

--- a/packages/devui-vue/devui/loading/src/loading.scss
+++ b/packages/devui-vue/devui/loading/src/loading.scss
@@ -15,6 +15,9 @@
 }
 
 .#{$devui-prefix}-loading__mask {
+
+  // to mask cover fixed column
+  z-index: $devui-z-index-full-page-overlay;
   position: absolute;
   left: 0;
   right: 0;
@@ -34,7 +37,7 @@
   right: 0;
   bottom: 0;
   top: 0;
-  z-index: 9999;
+  z-index: $devui-z-index-full-page-overlay;
 }
 
 .#{$devui-prefix}-loading--hidden {

--- a/packages/devui-vue/devui/styles-var/private/_z-index.scss
+++ b/packages/devui-vue/devui/styles-var/private/_z-index.scss
@@ -7,3 +7,4 @@ $devui-z-index-modal: var(--devui-z-index-modal, 1050);// 弹窗,
 $devui-z-index-message: var(--devui-z-index-modal, 1079);// 全局消息,
 $devui-z-index-drawer: var(--devui-z-index-drawer, 1040);// 抽屉板
 $devui-z-index-framework: var(--devui-z-index-framework, 1000);// 框架类元素，header,sideMenu等
+$devui-z-index-function-widget: var(--devui-z-index-function-widget, 999); // 功能控件类（在一个组件中处于最上层）

--- a/packages/devui-vue/devui/table/src/table.scss
+++ b/packages/devui-vue/devui/table/src/table.scss
@@ -4,11 +4,18 @@
   position: relative;
   width: 100%;
   overflow-x: auto;
+  display: flex;
 
   .hidden-columns {
     position: absolute;
     visibility: hidden;
     z-index: -1;
+  }
+
+  // fix v-dLoading can't completely covered
+  &__container {
+    flex: 1;
+    overflow: auto;
   }
 
   &__view {
@@ -122,7 +129,7 @@
     bottom: 0;
     width: 2px;
     background-color: $devui-form-control-line-active;
-    z-index: 9999;
+    z-index: $devui-z-index-function-widget;
     cursor: col-resize;
   }
 }

--- a/packages/devui-vue/devui/table/src/table.tsx
+++ b/packages/devui-vue/devui/table/src/table.tsx
@@ -50,15 +50,17 @@ export default defineComponent({
 
     return () => (
       <div ref={tableRef} class={ns.b()} style={styles.value} v-dLoading={props.showLoading}>
-        <div ref={hiddenColumns} class="hidden-columns">
-          {ctx.slots.default?.()}
+        <div class={ns.e('container')}>
+          <div ref={hiddenColumns} class="hidden-columns">
+            {ctx.slots.default?.()}
+          </div>
+          {props.fixHeader ? (
+            <FixHeader classes={classes.value} is-empty={isEmpty.value} />
+          ) : (
+            <NormalHeader classes={classes.value} is-empty={isEmpty.value} />
+          )}
+          {isEmpty.value && <div class={ns.e('empty')}>{ctx.slots.empty ? ctx.slots.empty() : props.empty}</div>}
         </div>
-        {props.fixHeader ? (
-          <FixHeader classes={classes.value} is-empty={isEmpty.value} />
-        ) : (
-          <NormalHeader classes={classes.value} is-empty={isEmpty.value} />
-        )}
-        {isEmpty.value && <div class={ns.e('empty')}>{ctx.slots.empty ? ctx.slots.empty() : props.empty}</div>}
       </div>
     );
   },

--- a/packages/devui-vue/docs/components/table/index.md
+++ b/packages/devui-vue/docs/components/table/index.md
@@ -1473,7 +1473,7 @@ export default defineComponent({
       setTimeout(() => {
         showLoading.value = false;
         dataSource.value = dataSource.value.concat(moreData);
-      }, 200);
+      }, 500);
     };
 
     return { dataSource, loadMore, showLoading };


### PR DESCRIPTION
## 修复方法：

为table组件内容新增一层父级`devui-table-container`，与loading同级，在`devui-table-container`中进行scroll操作，这样loading在外层不会随着滚动而滚动。

## 顺带修复一个z-index问题：

loadingMask没有设置z-index，导致在组件中存在无法覆盖全的问题，如固定列时，固定的列设置了 z-index: 5，会浮在loadingMask之上：

![image](https://user-images.githubusercontent.com/22699218/182779297-003b2b5e-27f7-4e58-a5f8-a4cf8b9060c9.png)

### 修复方法：为loadingMask增加最高层级zIndex - `$devui-z-index-full-page-overlay`

by the way，将项目中部分不规范的 `z-index: 9999` 修改，增加内容层最高层级zIndex - `$devui-z-index-function-widget` 使其不至于超过临时层导致其他问题

![image](https://user-images.githubusercontent.com/22699218/182779801-959cef30-8c20-40ab-b987-59d77205790a.png)
