### PR TITLE
fix(menu): 修复部分样式错误

### DIFF
--- a/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
+++ b/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
@@ -4,6 +4,7 @@ import { Menu, SubMenu, MenuItem } from '../index';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 
 const ns = useNamespace('menu');
+const SubNs = useNamespace('submenu');
 const dotNs = useNamespace('menu', true);
 const dotSubNs = useNamespace('submenu', true);
 
@@ -12,6 +13,9 @@ const menuHorizontal = ns.b() + '-horizontal';
 const dotMenuItem = dotNs.b() + '-item';
 const dotMenuItemVerticalWrapper = dotNs.b() + '-item-vertical-wrapper';
 const dotSubMenu = dotSubNs.b();
+const submenuDisabled = SubNs.b() + '-disabled';
+const menuitemDisabled = ns.b() + '-item-disabled';
+
 
 describe('menu test', () => {
   let wrapper: VueWrapper<ComponentPublicInstance>;
@@ -135,5 +139,32 @@ describe('menu test', () => {
     });
     expect(wrapper.findAll('i')[0].classes().includes('is-opened')).toBe(true);
     expect(wrapper.findAll('i')[1].classes().includes('is-opened')).toBe(false);
+  });
+
+  it('menu - disabled', async ()=>{
+    wrapper = wrapper = mount({
+      components: {
+        'd-menu': Menu,
+        'd-sub-menu': SubMenu,
+        'd-menu-item': MenuItem,
+      },
+      template: `
+      <d-menu>
+        <d-menu-item key="home">首页</d-menu-item>
+        <d-sub-menu title="课程" key="course" class="course" disabled>
+          <d-menu-item key="c"> C </d-menu-item>
+          <d-sub-menu title="Python" key="python">
+            <d-menu-item key="basic"> 基础 </d-menu-item>
+            <d-menu-item key="advanced"> 进阶 </d-menu-item>
+          </d-sub-menu>
+        </d-sub-menu>
+        <d-menu-item key="person">个人</d-menu-item>
+        <d-menu-item key="custom" href="https://www.baidu.com" disabled> Link To Baidu </d-menu-item>
+      </d-menu>
+      `,
+    });
+    await nextTick();
+    expect(wrapper.findAll(dotMenuItem).at(-1)?.classes().includes(menuitemDisabled)).toBe(true);
+    expect(wrapper.find('.course').classes().includes(submenuDisabled)).toBe(true);
   });
 });

--- a/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
+++ b/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
@@ -32,7 +32,6 @@ export default defineComponent({
     const rootMenuEmit = inject('rootMenuEmit') as (eventName: string, ...args: unknown[]) => void;
     const useRouter = inject('useRouter') as boolean;
     const router = instance?.appContext.config.globalProperties.$router as Router;
-
     const classObject = computed(()=>({
       [`${ns.b()}-item`]: true,
       [`${ns.b()}-item-isCollapsed`]: isCollapsed.value,
@@ -43,6 +42,7 @@ export default defineComponent({
       e.stopPropagation();
       const ele = e.currentTarget as HTMLElement;
       let changeRouteResult = undefined;
+      props.disabled && e.preventDefault();
       if (!props.disabled) {
         if (!multiple) {
           clearSelect(ele, e, mode.value === 'horizontal');
@@ -79,7 +79,9 @@ export default defineComponent({
     const icons = <span class={`${ns.b()}-icon`}>{ctx.slots.icon?.()}</span>;
     const menuItems = ref(null);
     watch(disabled, () => {
-      classObject.value[menuItemSelect] = false;
+      if (!multiple){
+        classObject.value[menuItemSelect] = false;
+      }
     });
     watch(
       () => defaultSelectKey,

--- a/packages/devui-vue/devui/menu/src/components/menu-item/use-menu-item.ts
+++ b/packages/devui-vue/devui/menu/src/components/menu-item/use-menu-item.ts
@@ -44,3 +44,15 @@ export function changeRoute(props: MenuItemProps, router: Router, useRouter: boo
   }
   return undefined;
 }
+
+export function changeSelect(isMultiple: boolean, defaultSelectKeys: string[], key: string): string[]{
+  if (isMultiple){
+    if (!defaultSelectKeys.indexOf(key)){
+      defaultSelectKeys.push(key);
+    }
+  } else{
+    defaultSelectKeys = [];
+    defaultSelectKeys.push(key);
+  }
+  return defaultSelectKeys;
+}

--- a/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
+++ b/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
@@ -1,12 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { defineComponent, getCurrentInstance, inject, onMounted, ref, watchEffect, watch } from 'vue';
 import type { ComponentInternalInstance, Ref } from 'vue';
-import { addLayer, pushElement, clearSelect, getLayer } from '../../composables/use-layer-operate';
-import { useClick } from '../../composables/use-click';
-import { useShowSubMenu } from './use-sub-menu';
-import { SubMenuProps, subMenuProps } from './sub-menu-types';
-import MenuTransition from '../menu-transition/menu-transition';
+import {
+  defineComponent,
+  getCurrentInstance,
+  inject,
+  onMounted,
+  ref,
+  watch,
+  watchEffect
+} from 'vue';
 import { useNamespace } from '../../../../shared/hooks/use-namespace';
+import { useClick } from '../../composables/use-click';
+import { addLayer, clearSelect, getLayer, pushElement } from '../../composables/use-layer-operate';
+import { useNearestMenuElement } from '../../composables/use-nearest-menu-element';
+import MenuTransition from '../menu-transition/menu-transition';
+import { SubMenuProps, subMenuProps } from './sub-menu-types';
+import { useShowSubMenu } from './use-sub-menu';
 
 const ns = useNamespace('menu');
 const subNs = useNamespace('submenu');
@@ -24,9 +33,9 @@ export default defineComponent({
     const {
       vnode: { key }
     } = getCurrentInstance() as ComponentInternalInstance;
-    const key_ = String(key);
-    const isOpen = ref(false);
+    let key_ = String(key);
     const defaultOpenKeys = inject('openKeys') as Ref<string[]>;
+    const isOpen = ref(defaultOpenKeys.value.includes(key_));
     const indent = inject('defaultIndent');
     const isCollapsed = inject('isCollapsed') as Ref<boolean>;
     const mode = inject('mode') as Ref<string>;
@@ -35,18 +44,11 @@ export default defineComponent({
     const isHorizontal = mode.value === 'horizontal';
     if (key_ === 'null') {
       console.warn(`[devui][menu]: Key can not be null`);
-    } else {
-      if (defaultOpenKeys.value.includes(key_)) {
-        isOpen.value = true;
-      } else {
-        isOpen.value = false;
-      }
+      key_ = `notKey-${new Date().getTime()} - ${Math.floor(Math.random()*10)}`;
     }
     const clickHandle = (e: MouseEvent) => {
-      e.preventDefault();
       e.stopPropagation();
-      const ele = e.currentTarget as HTMLElement;
-
+      const ele = useNearestMenuElement(e.target as HTMLElement);
       if (ele.classList.contains(subMenuClass) && isHorizontal) {
         return;
       }
@@ -55,26 +57,22 @@ export default defineComponent({
         useClick(e as clickEvent);
       }
       if (!props.disabled && mode.value !== 'horizontal') {
-        const target = e.target as HTMLElement;
-        let cur = e.target as HTMLElement;
-        if (target.tagName === 'UL') {
-          if (target.classList.contains(`${subMenuClass}-open`)) {
-            isOpen.value = !isOpen.value;
-          } else {
-            isOpen.value = isOpen.value;
-          }
+        const cur = useNearestMenuElement(e.target as HTMLElement);
+        const idx = defaultOpenKeys.value.indexOf(key_);
+        if (idx>=0 && cur.tagName === 'UL') {
+          defaultOpenKeys.value.splice(idx,1);
         } else {
-          while (cur && cur.tagName !== 'UL') {
-            if (cur.tagName === 'LI') {
-              break;
-            }
-            cur = cur.parentElement as HTMLElement;
-          }
-          if (cur.tagName === 'UL') {
-            isOpen.value = !isOpen.value;
+          if (cur.tagName === 'UL'){
+            defaultOpenKeys.value.push(key_);
           }
         }
-        parentEmit('submenu-change', { type: 'submenu-change', state: isOpen.value, key: key_, el: cur });
+        isOpen.value = defaultOpenKeys.value.indexOf(key_) >= 0;
+        parentEmit('submenu-change', {
+          type: 'submenu-change',
+          state: isOpen.value,
+          key: key_,
+          el: ele
+        });
       }
     };
     const wrapper = ref(null);
@@ -93,7 +91,7 @@ export default defineComponent({
     watch(
       () => defaultOpenKeys,
       (n) => {
-        if (n.value.includes(key_)) {
+        if (n.value.includes(key_)){
           isOpen.value = true;
         } else {
           isOpen.value = false;
@@ -101,11 +99,11 @@ export default defineComponent({
       },{deep: true}
     );
     onMounted(() => {
-      const el = title.value as unknown as HTMLElement;
-      const e = subMenu.value as unknown as HTMLElement;
+      const subMenuTitle = title.value as unknown as HTMLElement;
+      const subMenuWrapper = subMenu.value as unknown as HTMLElement;
       addLayer();
-      class_layer.value = `layer_${Array.from(e.classList).at(-1)?.replace('layer_', '')}`;
-      if (isHorizontal) {
+      class_layer.value = `layer_${Array.from(subMenuWrapper.classList).at(-1)?.replace('layer_', '')}`;
+      if (isHorizontal && !props.disabled) {
         (subMenu.value as unknown as Element as HTMLElement).addEventListener('mouseenter', (ev: MouseEvent) => {
           ev.stopPropagation();
           useShowSubMenu('mouseenter', ev, wrapperDom);
@@ -116,30 +114,34 @@ export default defineComponent({
         });
       }
       watch(isCollapsed, (newValue) => {
-        const layer = Number(getLayer(e));
+        const layer = Number(getLayer(subMenuWrapper));
         if (!Number.isNaN(layer)) {
           layer > 2 && (isShow.value = !isCollapsed.value);
         }
         if (newValue) {
-          el.style.padding !== '0' && (oldPadding = el.style.padding);
+          subMenuTitle.style.padding !== '0' && (oldPadding = subMenuTitle.style.padding);
           setTimeout(() => {
-            el.style.padding = '0';
-            el.style.width = '';
-            el.style.textAlign = `center`;
+            subMenuTitle.style.padding = '0';
+            subMenuTitle.style.width = '';
+            subMenuTitle.style.textAlign = `center`;
           }, 300);
-          el.style.display = `block`;
+          subMenuTitle.style.display = `block`;
         } else {
-          el.style.padding = `${oldPadding}`;
-          el.style.textAlign = ``;
-          el.style.display = `flex`;
+          subMenuTitle.style.padding = `${oldPadding}`;
+          subMenuTitle.style.textAlign = ``;
+          subMenuTitle.style.display = `flex`;
         }
       });
     });
     return () => {
       return (
-        <ul v-show={isShow.value} onClick={clickHandle} class={[subMenuClass, class_layer.value]} ref={subMenu}>
+        <ul
+          v-show={isShow.value}
+          onClick={clickHandle}
+          class={[subMenuClass, class_layer.value, props['disabled'] && `${subMenuClass}-disabled`]}
+          ref={subMenu}>
           <div
-            class={[`${subMenuClass}-title`, props['disabled'] && `${subMenuClass}-disabled`]}
+            class={[`${subMenuClass}-title`]}
             style={`padding: 0 ${indent}px`}
             ref={title}>
             <span class={`${ns.b()}-icon`}>{ctx.slots?.icon?.()}</span>
@@ -155,7 +157,11 @@ export default defineComponent({
               }}></i>
           </div>
           {isHorizontal ? (
-            <div class={`${ns.b()}-item-horizontal-wrapper ${ns.b()}-item-horizontal-wrapper-hidden`} ref={wrapper}>
+            <div
+              class={`${ns.b()}-item-horizontal-wrapper ${ns.b()}-item-horizontal-wrapper-hidden`}
+              ref={wrapper}
+              v-show={!props.disabled}
+            >
               {ctx.slots.default?.()}
             </div>
           ) : (

--- a/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
+++ b/packages/devui-vue/devui/menu/src/components/sub-menu/sub-menu.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { randomId } from '../../../../shared/utils/random-id';
 import type { ComponentInternalInstance, Ref } from 'vue';
 import {
   defineComponent,
@@ -40,11 +40,12 @@ export default defineComponent({
     const isCollapsed = inject('isCollapsed') as Ref<boolean>;
     const mode = inject('mode') as Ref<string>;
     const subMenuItemContainer = ref(null) as Ref<null>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parentEmit = inject('rootMenuEmit') as (eventName: 'submenu-change', ...args: any[]) => void;
     const isHorizontal = mode.value === 'horizontal';
     if (key_ === 'null') {
       console.warn(`[devui][menu]: Key can not be null`);
-      key_ = `notKey-${new Date().getTime()} - ${Math.floor(Math.random()*10)}`;
+      key_ = `randomKey-${randomId(16)}`;
     }
     const clickHandle = (e: MouseEvent) => {
       e.stopPropagation();
@@ -59,8 +60,8 @@ export default defineComponent({
       if (!props.disabled && mode.value !== 'horizontal') {
         const cur = useNearestMenuElement(e.target as HTMLElement);
         const idx = defaultOpenKeys.value.indexOf(key_);
-        if (idx>=0 && cur.tagName === 'UL') {
-          defaultOpenKeys.value.splice(idx,1);
+        if (idx >= 0 && cur.tagName === 'UL') {
+          defaultOpenKeys.value.splice(idx, 1);
         } else {
           if (cur.tagName === 'UL'){
             defaultOpenKeys.value.push(key_);
@@ -84,6 +85,7 @@ export default defineComponent({
     watchEffect(
       () => {
         wrapperDom = wrapper.value as unknown as HTMLElement;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         pushElement({ el: subMenu.value } as any);
       },
       { flush: 'post' }

--- a/packages/devui-vue/devui/menu/src/composables/use-nearest-menu-element.ts
+++ b/packages/devui-vue/devui/menu/src/composables/use-nearest-menu-element.ts
@@ -1,0 +1,6 @@
+export function useNearestMenuElement(ele: HTMLElement): HTMLElement{
+  while (ele && ele.tagName !== 'LI' && ele.tagName !== 'UL'){
+    ele = ele.parentElement as HTMLElement;
+  }
+  return ele;
+}

--- a/packages/devui-vue/devui/menu/src/menu.scss
+++ b/packages/devui-vue/devui/menu/src/menu.scss
@@ -8,6 +8,7 @@ $devui-menu-item: var(--devui-menu-item);
 $devui-menu-item-sub: var(--devui-menu-item-sub);
 $devui-menu-item-disabled: var(--devui-menu-disabled);
 $devui-menu-item-select: var(--devui-menu-item-hover);
+$devui-menu-item-hover: var(--devui-menu-item-hover);
 
 $devui-menu-item-selectBar: var(--devui-primary-hover, #5e7ce0);
 $devui-menu-active-parent: var(--devui-icon-fill-active);

--- a/packages/devui-vue/devui/menu/src/menu.tsx
+++ b/packages/devui-vue/devui/menu/src/menu.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, provide, ref, computed, onMounted, toRefs } from 'vue';
+import { defineComponent, provide, ref, computed, onMounted, toRefs, reactive } from 'vue';
 import type { ComponentPublicInstance } from 'vue';
 import { menuProps, MenuProps } from './menu-types';
 import './menu.scss';
@@ -25,14 +25,30 @@ export default defineComponent({
     provide('useRouter', props.router);
     setDefaultIndent(props['indentSize']);
     const menuRoot = ref(null);
-    const overflow_container = ref<ComponentPublicInstance | null>(null);
     const overflowItemLength = ref(0);
+    const overflow_container = ref<ComponentPublicInstance | null>(null);
+    const selectClassName = `${ns.b()}-item-select`;
     const rootClassName = computed(()=>({
       [`${ns.b()}`]: true,
       [`${ns.b()}-vertical`]: mode.value === 'vertical',
       [`${ns.b()}-horizontal`]: mode.value === 'horizontal',
       [`${ns.b()}-collapsed`]: collapsed.value
     }));
+    const overflowContainerClassName = reactive({
+      [selectClassName]: false,
+      [`${ns.b()}-overflow-container`]: true
+    });
+    const resetOverflowContainerSelectState = (e: Element) => {
+      const children = Array.from(e.children);
+      for (const item of children){
+        if (item.classList.contains(selectClassName)){
+          overflowContainerClassName[selectClassName] = true;
+          break;
+        } else {
+          overflowContainerClassName[selectClassName] = false;
+        }
+      }
+    };
     onMounted(() => {
       if (props['mode'] === 'horizontal') {
         let flag = false;
@@ -58,6 +74,7 @@ export default defineComponent({
                     root.appendChild(v.target);
                   }
                   container.appendChild(cloneNode);
+                  resetOverflowContainerSelectState(container);
                 }
               } else {
                 if (
@@ -65,12 +82,11 @@ export default defineComponent({
                   (v.target as HTMLElement).style.visibility === 'hidden'
                 ) {
                   ob.unobserve(v.target);
-                  const el = container.lastChild;
-                  if (el){
-                    root.insertBefore(el, overflowContainer);
-                  }
+                  root.insertBefore(v.target, overflowContainer);
+                  (v.target as HTMLElement).style.visibility = '';
                   const obItem = overflowContainer.previousElementSibling;
-                  if (obItem) {
+                  const canObAgin = obItem && (v.boundingClientRect.width % v.target.getBoundingClientRect().width === 0);
+                  if (canObAgin) {
                     ob.observe(obItem);
                   }
                   if (obItem?.classList.contains('devui-submenu')){
@@ -85,9 +101,12 @@ export default defineComponent({
                       useShowSubMenu('mouseleave', ev, wrapper);
                     });
                   }
-                  (v.target as HTMLElement).style.visibility = '';
-                  v.target.remove();
                   overflowItemLength.value -= 1;
+                  ob.observe(v.target);
+                  if (container.lastChild){
+                    container.removeChild(container.lastChild);
+                  }
+                  resetOverflowContainerSelectState(container);
                 }
               }
             });
@@ -110,14 +129,13 @@ export default defineComponent({
           class={rootClassName.value}
           style={[
             props['collapsed'] ? `width:${props['collapsedIndent'] * 2}px` : `width: ${props['width']}`,
-            'white-space: nowrap',
           ]}>
           {ctx.slots.default?.()}
           <SubMenu
             ref={overflow_container}
             key="overflowContainer"
             title="..."
-            class={`${ns.b()}-overflow-container`}
+            class={overflowContainerClassName}
             v-show={overflowItemLength.value > 0 && mode.value === 'horizontal'}>
           </SubMenu>
         </ul>

--- a/packages/devui-vue/devui/menu/src/menu.tsx
+++ b/packages/devui-vue/devui/menu/src/menu.tsx
@@ -26,7 +26,7 @@ export default defineComponent({
     setDefaultIndent(props['indentSize']);
     const menuRoot = ref(null);
     const overflowItemLength = ref(0);
-    const overflow_container = ref<ComponentPublicInstance | null>(null);
+    const overflowContainer = ref<ComponentPublicInstance | null>(null);
     const selectClassName = `${ns.b()}-item-select`;
     const rootClassName = computed(()=>({
       [`${ns.b()}`]: true,
@@ -38,6 +38,7 @@ export default defineComponent({
       [selectClassName]: false,
       [`${ns.b()}-overflow-container`]: true
     });
+    // 如果一个或多个菜单元素被选中，当宽度发生变化时。如果溢出容易中有被选中的元素，那么溢出容器也应当被选中
     const resetOverflowContainerSelectState = (e: Element) => {
       const children = Array.from(e.children);
       for (const item of children){
@@ -52,40 +53,40 @@ export default defineComponent({
     onMounted(() => {
       if (props['mode'] === 'horizontal') {
         let flag = false;
-        const overflowContainer = overflow_container.value?.$el as unknown as HTMLElement;
+        const overflowContainerElement = overflowContainer.value?.$el as unknown as HTMLElement;
         const root = menuRoot.value as unknown as HTMLElement;
         const children = root.children;
-        const container = overflowContainer.children[1];
+        const container = overflowContainerElement.children[1];
         const ob = new IntersectionObserver(
           (entries: IntersectionObserverEntry[]) => {
-            entries.forEach((v: IntersectionObserverEntry) => {
-              if (!v.isIntersecting) {
-                const cloneNode = v.target.cloneNode(true) as Element as HTMLElement;
-                if (v.target.classList.contains(`${ns.b()}-overflow-container`)){
-                  if (flag && v.target.previousElementSibling && container.children.length){
-                    root.appendChild(v.target.previousElementSibling);
+            entries.forEach((entry: IntersectionObserverEntry) => {
+              if (!entry.isIntersecting) {
+                const cloneNode = entry.target.cloneNode(true) as Element as HTMLElement;
+                if (entry.target.classList.contains(`${ns.b()}-overflow-container`)){
+                  if (flag && entry.target.previousElementSibling && container.children.length){
+                    root.appendChild(entry.target.previousElementSibling);
                   } else {flag = true;}
                 } else {
                   overflowItemLength.value += 1;
-                  (v.target as Element as HTMLElement).style.visibility = 'hidden';
-                  if (overflowContainer.nextSibling) {
-                    root.insertBefore(v.target, overflowContainer.nextSibling);
+                  (entry.target as Element as HTMLElement).style.visibility = 'hidden';
+                  if (overflowContainerElement.nextSibling) {
+                    root.insertBefore(entry.target, overflowContainerElement.nextSibling);
                   } else {
-                    root.appendChild(v.target);
+                    root.appendChild(entry.target);
                   }
                   container.appendChild(cloneNode);
                   resetOverflowContainerSelectState(container);
                 }
               } else {
                 if (
-                  !v.target.classList.contains(`${ns.b()}-overflow-container`) &&
-                  (v.target as HTMLElement).style.visibility === 'hidden'
+                  !entry.target.classList.contains(`${ns.b()}-overflow-container`) &&
+                  (entry.target as HTMLElement).style.visibility === 'hidden'
                 ) {
-                  ob.unobserve(v.target);
-                  root.insertBefore(v.target, overflowContainer);
-                  (v.target as HTMLElement).style.visibility = '';
-                  const obItem = overflowContainer.previousElementSibling;
-                  const canObAgin = obItem && (v.boundingClientRect.width % v.target.getBoundingClientRect().width === 0);
+                  ob.unobserve(entry.target);
+                  root.insertBefore(entry.target, overflowContainerElement);
+                  (entry.target as HTMLElement).style.visibility = '';
+                  const obItem = overflowContainerElement.previousElementSibling;
+                  const canObAgin = obItem && (entry.boundingClientRect.width % entry.target.getBoundingClientRect().width === 0);
                   if (canObAgin) {
                     ob.observe(obItem);
                   }
@@ -102,7 +103,7 @@ export default defineComponent({
                     });
                   }
                   overflowItemLength.value -= 1;
-                  ob.observe(v.target);
+                  ob.observe(entry.target);
                   if (container.lastChild){
                     container.removeChild(container.lastChild);
                   }
@@ -132,7 +133,7 @@ export default defineComponent({
           ]}>
           {ctx.slots.default?.()}
           <SubMenu
-            ref={overflow_container}
+            ref={overflowContainer}
             key="overflowContainer"
             title="..."
             class={overflowContainerClassName}

--- a/packages/devui-vue/devui/menu/src/styles/clear.scss
+++ b/packages/devui-vue/devui/menu/src/styles/clear.scss
@@ -1,6 +1,9 @@
 .#{$devui-prefix}-menu-vertical,
 .#{$devui-prefix}-menu-horizontal {
-  a {
+  a,
+  a:hover,
+  a:active,
+  a:visited {
     text-decoration: none;
   }
 

--- a/packages/devui-vue/devui/menu/src/styles/horizontal.scss
+++ b/packages/devui-vue/devui/menu/src/styles/horizontal.scss
@@ -170,4 +170,20 @@
       }
     }
   }
+
+  .#{$devui-prefix}-menu-item-disabled,
+  .#{$devui-prefix}-submenu-disabled {
+    span,
+    a {
+      color: $devui-menu-item-disabled !important;
+      cursor: not-allowed;
+    }
+
+    &::after {
+      content: unset !important;
+    }
+    &+.#{$devui-prefix}-menu-item-horizontal-wrapper {
+      display: none;
+    }
+  }
 }

--- a/packages/devui-vue/devui/menu/src/styles/public.scss
+++ b/packages/devui-vue/devui/menu/src/styles/public.scss
@@ -3,12 +3,6 @@
   margin-left: $devui-menu-item-margin;
 }
 
-.#{$devui-prefix}-menu-item-disabled,
-.#{$devui-prefix}-submenu-disabled {
-  color: $devui-menu-item-disabled !important;
-  cursor: not-allowed !important;
-}
-
 .#{$devui-prefix}-menu-item-disabled:hover,
 .#{$devui-prefix}-submenu-disabled:hover {
   color: $devui-menu-item-disabled !important;
@@ -33,4 +27,14 @@
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+
+.#{$devui-prefix}-menu-item-disabled,
+.#{$devui-prefix}-menu-item-disabled.devui-menu-vertical
+.#{$devui-prefix}-menu-item-disabled.devui-menu-item-select
+.#{$devui-prefix}-submenu-disabled,
+.#{$devui-prefix}-submenu-disabled.devui-menu-vertical,
+.#{$devui-prefix}-submenu-disabled.devui-menu-item-select {
+  color: $devui-menu-item-disabled !important;
+  cursor: not-allowed !important;
 }

--- a/packages/devui-vue/devui/menu/src/styles/vertical.scss
+++ b/packages/devui-vue/devui/menu/src/styles/vertical.scss
@@ -1,7 +1,9 @@
 .#{$devui-prefix}-submenu-menu-item-vertical-wrapper {
   overflow: hidden;
 }
-
+.#{$devui-prefix}-submenu-menu-item {
+  color: $devui-menu-item;
+}
 .#{$devui-prefix}-menu-vertical {
   padding: 0;
   transition:
@@ -80,6 +82,74 @@
     opacity: 1;
     background: $devui-menu-item-selectBar;
   }
+  // sub menu
+  ul.#{$devui-prefix}-submenu {
+    margin: 0;
+    padding: 0;
+    .#{$devui-prefix}-menu-item {
+      display: flex;
+      background: $devui-area;
+
+      & > span {
+        flex: auto;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
+        color: $devui-menu-item;
+      }
+    }
+    div.#{$devui-prefix}-submenu-title {
+      display: flex;
+      cursor: pointer;
+      width: 100%;
+      height: 40px;
+      margin: 4px 0;
+      line-height: 40px;
+      padding-left: 18px;
+      align-items: center;
+      color: $devui-menu-item;
+
+      &:nth-child(1) {
+        font-size: $devui-font-size-lg;
+      }
+
+      span.#{$devui-prefix}-submenu-title-content {
+        font-size: $devui-font-size-lg;
+        flex: auto;
+        color: $devui-menu-item;
+      }
+
+      span.#{$devui-prefix}-menu-icon {
+        text-align: center;
+      }
+
+      .icon-chevron-up {
+        transition: transform $devui-animation-duration-slow $devui-animation-ease-in-out-smooth;
+      }
+
+      i.icon-chevron-up.is-opened {
+        transform: rotate(180deg);
+      }
+    }
+    .#{$devui-prefix}-submenu-title:hover {
+      span {
+        color: $devui-menu-item-hover !important;
+      }
+    }
+
+    .#{$devui-prefix}-menu-item:hover {
+      span {
+        color: $devui-menu-item-select;
+      }
+    }
+
+    .#{$devui-prefix}-menu-item-select {
+      * {
+        color: $devui-menu-item-select !important;
+      }
+    }
+  }
 
   .#{$devui-prefix}-menu-item-select {
     background: $devui-primary-bg !important;
@@ -101,12 +171,6 @@
       opacity: 1;
       background: var(--devui-brand, #5e7ce0);
       transform: scaleX(1);
-    }
-  }
-
-  .#{$devui-prefix}-submenu > div:hover {
-    span.#{$devui-prefix}-submenu-title-content {
-      color: $devui-menu-item-select;
     }
   }
 
@@ -138,75 +202,22 @@
     }
   }
 
-  // sub menu
-  ul.#{$devui-prefix}-submenu {
-    margin: 0;
-    padding: 0;
-
-    div.#{$devui-prefix}-submenu-title {
-      display: flex;
-      cursor: pointer;
-      width: 100%;
-      height: 40px;
-      margin: 4px 0;
-      line-height: 40px;
-      padding-left: 18px;
-      align-items: center;
-      color: $devui-menu-item;
-
-      &:nth-child(1) {
-        font-size: $devui-font-size-lg;
-      }
-
-      span.#{$devui-prefix}-submenu-title-content {
-        font-size: $devui-font-size-lg;
-        flex: auto;
-      }
-
-      span.#{$devui-prefix}-menu-icon {
-        text-align: center;
-      }
-
-      .icon-chevron-up {
-        transition: transform $devui-animation-duration-slow $devui-animation-ease-in-out-smooth;
-      }
-
-      i.icon-chevron-up.is-opened {
-        transform: rotate(180deg);
-      }
-    }
-
-    .#{$devui-prefix}-menu-item {
-      display: flex;
-
-      & > span {
-        flex: auto;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        transition: all $devui-animation-duration-fast $devui-animation-ease-in-smooth;
-        color: $devui-menu-item-sub;
-      }
-    }
-
-    .#{$devui-prefix}-menu-item:hover {
-      & > span {
-        color: $devui-menu-item-select;
-      }
-    }
-
-    .#{$devui-prefix}-menu-item-select {
-      * {
-        color: $devui-menu-item-select !important;
-      }
-    }
-  }
-
   ul li ~ ul > div {
     margin-top: 0 !important;
   }
-
-  ul li {
-    background: $devui-area !important;
+  .#{$devui-prefix}-menu-item-disabled,
+  .#{$devui-prefix}-submenu-disabled {
+    * {
+      color: $devui-menu-item-disabled !important;
+      cursor: not-allowed !important;
+      background: $devui-block !important;
+    }
+    // color: $devui-menu-item-disabled !important;
+    // cursor: not-allowed !important;
+    // background: $devui-block !important;
+  }
+  .#{$devui-prefix}-menu-item-disabled::after,
+  .#{$devui-prefix}-submenu-disabled::after {
+    content: unset;
   }
 }

--- a/packages/devui-vue/devui/menu/src/styles/vertical.scss
+++ b/packages/devui-vue/devui/menu/src/styles/vertical.scss
@@ -212,9 +212,6 @@
       cursor: not-allowed !important;
       background: $devui-block !important;
     }
-    // color: $devui-menu-item-disabled !important;
-    // cursor: not-allowed !important;
-    // background: $devui-block !important;
   }
   .#{$devui-prefix}-menu-item-disabled::after,
   .#{$devui-prefix}-submenu-disabled::after {

--- a/packages/devui-vue/docs/components/menu/index.md
+++ b/packages/devui-vue/docs/components/menu/index.md
@@ -21,13 +21,13 @@ Menu 组件通常用于导航.
     </d-menu-item>
     <d-sub-menu title="课程" key="course">
       <d-menu-item key="c"> C </d-menu-item>
-      <d-sub-menu title="Python" key="python">
+      <d-sub-menu title="Python" key="python" disabled>
         <d-menu-item key="basic"> 基础 </d-menu-item>
         <d-menu-item key="advanced"> 进阶 </d-menu-item>
       </d-sub-menu>
     </d-sub-menu>
     <d-menu-item key="person">个人</d-menu-item>
-    <d-menu-item key="custom" href="https://www.baidu.com"> Link To Baidu </d-menu-item>
+    <d-menu-item key="custom" href="https://www.baidu.com" disabled> Link To Baidu </d-menu-item>
   </d-menu>
   <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
@@ -82,14 +82,14 @@ let width = ref(480);
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -127,13 +127,14 @@ let width = ref(480);
 
 :::
 
-### 仅一项展开
+### 仅展开一项根子菜单
 
 :::demo 通过子菜单状态改变事件修改```open-keys```数组达到效果
 
 ``` vue
   <template>
-    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px">
+    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px"
+    >
       <d-sub-menu title="submenu-1" key="submenu-1">
         <template #icon>
           <i class="icon-infomation"></i>
@@ -141,6 +142,22 @@ let width = ref(480);
         <d-menu-item key="subemenu-item-1">
           <span>submenu-item-1</span>
         </d-menu-item>
+        <d-sub-menu title="submenu-4" key="submenu-4">
+          <template #icon>
+            <i class="icon-infomation"></i>
+          </template>
+          <d-menu-item key="subemenu-item-1">
+            <span>submenu-item-1</span>
+          </d-menu-item>
+        </d-sub-menu>
+        <d-sub-menu title="submenu-5" key="submenu-5">
+          <template #icon>
+            <i class="icon-infomation"></i>
+          </template>
+          <d-menu-item key="subemenu-item-1">
+            <span>submenu-item-1</span>
+          </d-menu-item>
+        </d-sub-menu>
       </d-sub-menu>
       <d-sub-menu title="submenu-2" key="submenu-2">
         <template #icon>
@@ -167,12 +184,16 @@ let width = ref(480);
   export default defineComponent({
     setup() {
       const openKeys = ref(['submenu-1']);
+      const rootSubMenuKeys = ref(['submenu-1','submenu-2','submenu-3']);
       const submenuChange = (e) => {
-        console.log(e)
-        openKeys.value.forEach(element => {
-          openKeys.value.shift()
-        });
-        openKeys.value.push(e.key)
+        console.log(e);
+        const {key} = e;
+        if (rootSubMenuKeys.value.includes(key)){
+          while (openKeys.value.length){
+            openKeys.value.shift();
+          }
+          openKeys.value.push(key);
+        }
       };
       return {
         openKeys,
@@ -204,14 +225,14 @@ let width = ref(480);
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -246,7 +267,7 @@ const changeCollapsed = () => {
       <template #icon>
         <i class="icon-setting"></i>
       </template>
-      <d-menu-item key="setting">
+      <d-menu-item key="setting-item">
         <span>Setting item</span>
       </d-menu-item>
     </d-sub-menu>
@@ -299,14 +320,14 @@ export default defineComponent({
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="icon-setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>

--- a/packages/devui-vue/docs/en-US/components/menu/index.md
+++ b/packages/devui-vue/docs/en-US/components/menu/index.md
@@ -27,7 +27,7 @@ When you need to store, arrange and display a series of options
       </d-sub-menu>
     </d-sub-menu>
     <d-menu-item key="person">个人</d-menu-item>
-    <d-menu-item key="custom" href="https://www.baidu.com"> Link To Baidu </d-menu-item>
+    <d-menu-item key="custom" href="https://www.baidu.com" disabled> Link To Baidu </d-menu-item>
   </d-menu>
   <d-slider :min="0" :max="480" v-model="width"></d-slider>
 </template>
@@ -82,14 +82,14 @@ Vertical menus are generally widely used in the background, and submenus can be 
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -147,14 +147,14 @@ You can modify the expanded submenu items by setting 'open keys'
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>
@@ -189,7 +189,7 @@ The function of canceling multiple selection can only be used in menus that allo
       <template #icon>
         <i class="icon-setting"></i>
       </template>
-      <d-menu-item key="setting">
+      <d-menu-item key="setting-item">
         <span>Setting item</span>
       </d-menu-item>
     </d-sub-menu>
@@ -228,7 +228,8 @@ export default defineComponent({
 
 ``` vue
   <template>
-    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px">
+    <d-menu @submenu-change="submenuChange" :default-select-keys="['item1']" :open-keys="openKeys" width="256px"
+    >
       <d-sub-menu title="submenu-1" key="submenu-1">
         <template #icon>
           <i class="icon-infomation"></i>
@@ -236,6 +237,22 @@ export default defineComponent({
         <d-menu-item key="subemenu-item-1">
           <span>submenu-item-1</span>
         </d-menu-item>
+        <d-sub-menu title="submenu-4" key="submenu-4">
+          <template #icon>
+            <i class="icon-infomation"></i>
+          </template>
+          <d-menu-item key="subemenu-item-4">
+            <span>submenu-item-1</span>
+          </d-menu-item>
+        </d-sub-menu>
+        <d-sub-menu title="submenu-5" key="submenu-5">
+          <template #icon>
+            <i class="icon-infomation"></i>
+          </template>
+          <d-menu-item key="subemenu-item-5">
+            <span>submenu-item-1</span>
+          </d-menu-item>
+        </d-sub-menu>
       </d-sub-menu>
       <d-sub-menu title="submenu-2" key="submenu-2">
         <template #icon>
@@ -249,7 +266,7 @@ export default defineComponent({
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="submenu-item-2">
+        <d-menu-item key="submenu-item-6">
           <span>submenu-item-2</span>
         </d-menu-item>
       </d-sub-menu>
@@ -262,12 +279,16 @@ export default defineComponent({
   export default defineComponent({
     setup() {
       const openKeys = ref(['submenu-1']);
+      const rootSubMenuKeys = ref(['submenu-1','submenu-2','submenu-3']);
       const submenuChange = (e) => {
-        console.log(e)
-        openKeys.value.forEach(element => {
-          openKeys.value.shift()
-        });
-        openKeys.value.push(e.key)
+        console.log(e);
+        const {key} = e;
+        if (rootSubMenuKeys.value.includes(key)){
+          while (openKeys.value.length){
+            openKeys.value.shift();
+          }
+          openKeys.value.push(key);
+        }
       };
       return {
         openKeys,
@@ -299,14 +320,14 @@ eg. `width`, `open-keys`, `default-select-keys`
       <template #icon>
         <i class="icon-system"></i>
       </template>
-      <d-menu-item key="system">
+      <d-menu-item key="system-item">
         <span>System item</span>
       </d-menu-item>
       <d-sub-menu title="Setting" key="icon-setting">
         <template #icon>
           <i class="icon-setting"></i>
         </template>
-        <d-menu-item key="setting">
+        <d-menu-item key="setting-item">
           <span>Setting item</span>
         </d-menu-item>
       </d-sub-menu>


### PR DESCRIPTION
- 逻辑修复
    - 修复溢出菜单中，router无法点击
    - 修复溢出再显示后无法点击的bug
    - 修复溢出菜单再显示，最后一个元素闪烁问题
- 单元测试
    - 增加单元测试
- 样式修复
    - 修复如果鼠标悬浮在任何一个menu-element上，同级的其他menu-element也会有hover的样式。
- 文档
    - 添加 仅展开一项
    - 修复 key错误