### PR TITLE
fix(input-number): 修复ts类型错误，输入框输入非数字显示异常等问题

### DIFF
--- a/packages/devui-vue/devui/input-number/src/input-number-types.ts
+++ b/packages/devui-vue/devui/input-number/src/input-number-types.ts
@@ -55,7 +55,7 @@ export interface UseRender {
 }
 
 export interface UseEvent {
-  inputVal: ComputedRef<number | string>;
+  inputVal: ComputedRef<number | string | undefined>;
   minDisabled: ComputedRef<boolean>;
   maxDisabled: ComputedRef<boolean>;
   onAdd: () => void;

--- a/packages/devui-vue/devui/input-number/src/input-number.tsx
+++ b/packages/devui-vue/devui/input-number/src/input-number.tsx
@@ -27,7 +27,6 @@ export default defineComponent({
         </div>
         <div class={inputWrapClass.value}>
           <input
-            type="number"
             ref={inputRef}
             value={inputVal.value}
             placeholder={props.placeholder}


### PR DESCRIPTION
1. input 的输入框类型不应该为 number, number类型输入非数字不会触发更新事件导致输入框内容显示异常。
2. 修复 inputVal ts 类型错误
3. 输入不合规的字符，显示最后一次正确值。
4. 其他一些优化
<img width="949" alt="截屏2022-08-06 下午6 24 26" src="https://user-images.githubusercontent.com/52314078/183244965-960c4c64-292a-4d1d-8b12-a3c254348948.png">
