### PR TITLE
chore: add .code-workspace file

### DIFF
--- a/vue-devui.code-workspace
+++ b/vue-devui.code-workspace
@@ -1,0 +1,8 @@
+{
+  "folders": [
+    { "name": "root", "path": "." },
+    { "name": "devui-cli", "path": "./packages/devui-cli" },
+    { "name": "devui-theme", "path": "./packages/devui-theme" },
+    { "name": "devui-vue", "path": "./packages/devui-vue" }
+  ]
+}


### PR DESCRIPTION
This PR improves developers experience(DX) by add a .code-workspace file to enable IDE monorepo enhancement.

## Previous

Pain points:
- Hard to read our file structure because sub projects inside `packages/**` are too deep.

![image](https://user-images.githubusercontent.com/74389358/183299487-bea948e2-f51f-4284-8432-701a05028e3d.png)

## Now

![image](https://user-images.githubusercontent.com/74389358/183299496-0efa0a1d-eb59-452a-972e-e7a0acef0985.png)
