### PR TITLE
fix: 更新弹出类组件的层级，避免被遮挡

### DIFF
--- a/packages/devui-vue/devui/auto-complete/src/auto-complete.tsx
+++ b/packages/devui-vue/devui/auto-complete/src/auto-complete.tsx
@@ -113,7 +113,11 @@ export default defineComponent({
     const renderBasicDropdown = () => {
       return (
         <Transition name={showAnimation ? 'fade' : ''}>
-          <FlexibleOverlay origin={origin.value} position={position.value} v-model={visible.value}>
+          <FlexibleOverlay
+            origin={origin.value}
+            position={position.value}
+            v-model={visible.value}
+            style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
             <div
               class={ns.e('menu')}
               style={{

--- a/packages/devui-vue/devui/cascader/src/cascader.scss
+++ b/packages/devui-vue/devui/cascader/src/cascader.scss
@@ -51,7 +51,6 @@
 
   &__drop-menu-animation {
     transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
-    z-index: 1000;
   }
 
   &__dropdown-menu {

--- a/packages/devui-vue/devui/cascader/src/cascader.tsx
+++ b/packages/devui-vue/devui/cascader/src/cascader.tsx
@@ -84,7 +84,8 @@ export default defineComponent({
               ref={overlayRef}
               v-model={menuShow.value}
               position={position.value as Placement[]}
-              align="start">
+              align="start"
+              style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
               <div class={ns.e('drop-menu-animation')}>
                 {!isSearching.value && (
                   <div class={`${menuOpenClass.value} ${ns.e('dropdown-menu')}`}>

--- a/packages/devui-vue/devui/date-picker-pro/src/components/range-date-picker-pro.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/src/components/range-date-picker-pro.tsx
@@ -126,7 +126,8 @@ export default defineComponent({
                 ref={overlayRef}
                 origin={originRef.value}
                 align="start"
-                position={position.value}>
+                position={position.value}
+                style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
                 <DatePickerProPanel
                   {...props}
                   dateValue={dateValue.value}

--- a/packages/devui-vue/devui/date-picker-pro/src/date-picker-pro.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/src/date-picker-pro.tsx
@@ -80,7 +80,8 @@ export default defineComponent({
                 ref={overlayRef}
                 origin={originRef.value}
                 align="start"
-                position={position.value}>
+                position={position.value}
+                style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
                 <DatePickerProPanel
                   {...props}
                   dateValue={dateValue.value}

--- a/packages/devui-vue/devui/drawer/src/drawer-types.ts
+++ b/packages/devui-vue/devui/drawer/src/drawer-types.ts
@@ -7,7 +7,7 @@ export const drawerProps = {
   },
   zIndex: {
     type: Number,
-    default: 1000,
+    default: 1040,
   },
   showOverlay: {
     type: Boolean,
@@ -41,7 +41,7 @@ export const drawerOverlayProps = {
   },
   onClick: {
     type: Function,
-  }
+  },
 };
 
 type DrawerEmitEvent = 'update:modelValue' | 'close' | 'open';

--- a/packages/devui-vue/devui/drawer/src/drawer.tsx
+++ b/packages/devui-vue/devui/drawer/src/drawer.tsx
@@ -12,11 +12,13 @@ export default defineComponent({
   setup(props: DrawerProps, { emit, slots, attrs }) {
     const { drawerRef, drawerClasses, handleOverlayClick } = useDrawer(props, emit);
     return () => (
-      <Teleport to='body'>
-        {props.showOverlay && <DrawerOverlay visible={props.modelValue} style={{ zIndex: props.zIndex }} onClick={handleOverlayClick} />}
+      <Teleport to="body">
+        {props.showOverlay && (
+          <DrawerOverlay visible={props.modelValue} style={{ zIndex: props.zIndex - 1 }} onClick={handleOverlayClick} />
+        )}
         <Transition name={`drawer-fly-${props.position}`}>
           {props.modelValue && (
-            <div ref={drawerRef} class={drawerClasses.value} style={{ zIndex: props.zIndex + 1 }} {...attrs}>
+            <div ref={drawerRef} class={drawerClasses.value} style={{ zIndex: props.zIndex }} {...attrs}>
               {slots.default?.()}
             </div>
           )}

--- a/packages/devui-vue/devui/dropdown/src/use-dropdown.ts
+++ b/packages/devui-vue/devui/dropdown/src/use-dropdown.ts
@@ -171,6 +171,7 @@ export function useOverlayProps(props: DropdownProps, currentPosition: Ref<strin
   const overlayShowValue = ref<boolean>(false);
   const styles = computed(() => ({
     transformOrigin: currentPosition.value === 'top' ? '0% 100%' : '0% 0%',
+    zIndex: 'var(--devui-z-index-dropdown, 1052)',
   }));
   const classes = computed(() => ({
     'fade-in-bottom': showAnimation.value && isOpen.value && currentPosition.value === 'bottom',

--- a/packages/devui-vue/devui/editable-select/src/editable-select.tsx
+++ b/packages/devui-vue/devui/editable-select/src/editable-select.tsx
@@ -162,7 +162,11 @@ export default defineComponent({
           </span>
           <Teleport to="body">
             <Transition name="fade">
-              <FlexibleOverlay origin={origin.value} v-model={visible.value} position={position.value}>
+              <FlexibleOverlay
+                origin={origin.value}
+                v-model={visible.value}
+                position={position.value}
+                style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
                 <div
                   style={{
                     width: props.width + 'px',

--- a/packages/devui-vue/devui/image-preview/src/image-preview.scss
+++ b/packages/devui-vue/devui/image-preview/src/image-preview.scss
@@ -6,7 +6,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  z-index: calc(#{$devui-z-index-modal});
+  z-index: $devui-z-index-full-page-overlay;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,7 +20,7 @@
   }
   @mixin fixed-button() {
     position: fixed;
-    z-index: $devui-z-index-modal;
+    z-index: $devui-z-index-full-page-overlay;
     cursor: pointer;
     width: 36px;
     height: 36px;
@@ -120,6 +120,6 @@
   top: 0;
   right: 0;
   bottom: 0;
-  z-index: calc(#{$devui-z-index-modal} - 1);
+  z-index: calc($devui-z-index-full-page-overlay - 1);
   background: $devui-shadow;
 }

--- a/packages/devui-vue/devui/modal/src/modal-types.ts
+++ b/packages/devui-vue/devui/modal/src/modal-types.ts
@@ -48,16 +48,8 @@ export const modalProps = {
   },
   type: {
     type: String as PropType<ModalType>,
-    default: ''
+    default: '',
   },
-  width: {
-    type: [Number, String],
-    default: 300
-  },
-  top: {
-    type: [Number, String],
-    default: '15vh'
-  }
 };
 
 export type EmitName = 'update:modelValue';

--- a/packages/devui-vue/devui/modal/src/modal.scss
+++ b/packages/devui-vue/devui/modal/src/modal.scss
@@ -15,6 +15,7 @@
 
 .#{$devui-prefix}-modal {
   position: relative;
+  width: 300px;
   margin: auto;
   border-radius: $devui-border-radius;
   border: none;

--- a/packages/devui-vue/devui/modal/src/modal.tsx
+++ b/packages/devui-vue/devui/modal/src/modal.tsx
@@ -75,7 +75,7 @@ export default defineComponent({
           <div class={ns.e('container')} onClick={withModifiers(onOverlayClick, ['self'])}>
             <Transition name={props.showAnimation ? ns.m('wipe') : ''}>
               {showModal.value && (
-                <div ref={dialogRef} class={ns.b()} {...attrs} onClick={withModifiers(() => ({}), ['stop'])}>
+                <div ref={dialogRef} class={ns.b()} {...attrs}>
                   {showClose.value && (
                     <div onClick={onCloseBtnClick} class="btn-close">
                       <Icon name="close" size="20px"></Icon>

--- a/packages/devui-vue/devui/modal/src/modal.tsx
+++ b/packages/devui-vue/devui/modal/src/modal.tsx
@@ -27,17 +27,6 @@ export default defineComponent({
     const { showContainer, showModal } = useModalRender(props);
     const dialogRef = ref<HTMLElement>();
     const headerRef = ref<HTMLElement>();
-    const modalWidth = computed(() => {
-      if (typeof props.width === 'string') {
-        if ((props.width as string).includes('%')) {
-          return props.width;
-        } else {
-          return props.width + 'px';
-        }
-      } else {
-        return props.width + 'px';
-      }
-    });
     const draggable = computed(() => props.draggable);
     useDraggable(dialogRef, headerRef, draggable);
 
@@ -83,18 +72,10 @@ export default defineComponent({
           <FixedOverlay v-model={modelValue.value} lock-scroll={false} style={{ zIndex: 'calc(var(--devui-z-index-modal, 1050) - 1)' }} />
         )}
         {showContainer.value && (
-          <div
-            class={ns.e('container')}
-            onClick={withModifiers(onOverlayClick, ['stop'])}
-            onPointerup={withModifiers(() => ({}), ['stop'])}>
+          <div class={ns.e('container')} onClick={withModifiers(onOverlayClick, ['self'])}>
             <Transition name={props.showAnimation ? ns.m('wipe') : ''}>
               {showModal.value && (
-                <div
-                  ref={dialogRef}
-                  class={ns.b()}
-                  style={{ width: modalWidth.value, marginTop: props.top }}
-                  {...attrs}
-                  onClick={withModifiers(() => ({}), ['stop'])}>
+                <div ref={dialogRef} class={ns.b()} {...attrs} onClick={withModifiers(() => ({}), ['stop'])}>
                   {showClose.value && (
                     <div onClick={onCloseBtnClick} class="btn-close">
                       <Icon name="close" size="20px"></Icon>

--- a/packages/devui-vue/devui/notification/src/notification.scss
+++ b/packages/devui-vue/devui/notification/src/notification.scss
@@ -7,7 +7,7 @@
   width: 20em;
   word-break: normal;
   word-wrap: break-word;
-  z-index: 1060;
+  z-index: $devui-z-index-pop-up;
 
   a {
     &:link,

--- a/packages/devui-vue/devui/popover/src/use-popover.ts
+++ b/packages/devui-vue/devui/popover/src/use-popover.ts
@@ -19,7 +19,7 @@ export function usePopover(
 ): { overlayStyles: ComputedRef<Record<string, number | string>> } {
   const { trigger, isOpen } = toRefs(props);
   const overlayStyles = computed(() => ({
-    zIndex: 1060,
+    zIndex: 'var(--devui-z-index-pop-up, 1060)',
     transformOrigin: TransformOriginMap[placement.value],
   }));
 

--- a/packages/devui-vue/devui/select/src/select.tsx
+++ b/packages/devui-vue/devui/select/src/select.tsx
@@ -129,7 +129,10 @@ export default defineComponent({
                 align="start"
                 offset={4}
                 position={position.value}
-                style={{ visibility: isOpen.value ? 'visible' : 'hidden', 'z-index': isOpen.value ? 1000 : -1 }}>
+                style={{
+                  visibility: isOpen.value ? 'visible' : 'hidden',
+                  'z-index': isOpen.value ? 'var(--devui-z-index-dropdown, 1052)' : -1,
+                }}>
                 <div class={dropdownCls} style={{ width: `${dropdownWidth.value}`, visibility: isOpen.value ? 'visible' : 'hidden' }}>
                   <ul class={listCls} v-show={!isLoading.value}>
                     {isShowCreateOption.value && (

--- a/packages/devui-vue/devui/time-picker/src/time-picker.tsx
+++ b/packages/devui-vue/devui/time-picker/src/time-picker.tsx
@@ -86,7 +86,8 @@ export default defineComponent({
                 ref={overlayRef}
                 origin={inputDom.value?.$el}
                 position={position.value as Placement[]}
-                align="start">
+                align="start"
+                style={{ zIndex: 'var(--devui-z-index-dropdown, 1052)' }}>
                 <TimePopup
                   ref={timePopupDom}
                   showPopup={showPopup.value}

--- a/packages/devui-vue/docs/components/modal/index.md
+++ b/packages/devui-vue/docs/components/modal/index.md
@@ -190,22 +190,20 @@ export default defineComponent({
 
 ### Modal 参数
 
-| 参数名                 | 类型             | 默认值 | 说明                                       | 跳转 Demo                 |
-| :--------------------- | :--------------- | :----- | :----------------------------------------- | :------------------------ |
-| v-model                | `boolean`        | false  | 是否显示 Modal                             | [基础用法](#基础用法)     |
-| title                  | `string`         | -      | 可选，Modal 的标题                         | [基础用法](#基础用法)     |
-| lock-scroll            | `boolean`        | true   | 可选，是否将 body 滚动锁定                 |
-| close-on-click-overlay | `boolean`        | true   | 可选，点击空白处是否能关闭 Modal           |
-| before-close           | `(done) => void` | -      | 可选，关闭前的回调，调用 done 可关闭 Modal | [关闭前回调](#关闭前回调) |
-| escapable              | `boolean`        | true   | 可选，是否支持 esc 键关闭弹窗              |                           |
-| show-close             | `boolean`        | true   | 可选，是否展示关闭按钮                     |                           |
-| draggable              | `boolean`        | true   | 可选，弹框是否可拖拽                       |
-| show-animation           | `boolean`        | true   | 可选，是否显示动画
-| show-overlay           | `boolean`        | true   | 可选，是否展示遮罩层                       |                           |
-| append-to-body         | `boolean`        | true   | 可选，是否将 Modal 提升到 body 层          |                           |
-type | success \| failed \| warning \| info | - | 可选，弹框信息提示 |
-width | `number` / `string` | 300 | 可选，弹框宽度，支持百分比 |
-top | `number` / `string` | 15vh | 可选，弹框距离顶部距离 |
+| 参数名                 | 类型                                 | 默认值 | 说明                                       | 跳转 Demo                 |
+| :--------------------- | :----------------------------------- | :----- | :----------------------------------------- | :------------------------ |
+| v-model                | `boolean`                            | false  | 是否显示 Modal                             | [基础用法](#基础用法)     |
+| title                  | `string`                             | -      | 可选，Modal 的标题                         | [基础用法](#基础用法)     |
+| lock-scroll            | `boolean`                            | true   | 可选，是否将 body 滚动锁定                 |
+| close-on-click-overlay | `boolean`                            | true   | 可选，点击空白处是否能关闭 Modal           |
+| before-close           | `(done) => void`                     | -      | 可选，关闭前的回调，调用 done 可关闭 Modal | [关闭前回调](#关闭前回调) |
+| escapable              | `boolean`                            | true   | 可选，是否支持 esc 键关闭弹窗              |                           |
+| show-close             | `boolean`                            | true   | 可选，是否展示关闭按钮                     |                           |
+| draggable              | `boolean`                            | true   | 可选，弹框是否可拖拽                       |
+| show-animation         | `boolean`                            | true   | 可选，是否显示动画                         |
+| show-overlay           | `boolean`                            | true   | 可选，是否展示遮罩层                       |                           |
+| append-to-body         | `boolean`                            | true   | 可选，是否将 Modal 提升到 body 层          |                           |
+| type                   | success \| failed \| warning \| info | -      | 可选，弹框信息提示                         |
 
 ### Modal 插槽
 


### PR DESCRIPTION
1、参考`z-index.scss`文件的规范，更新弹出类组件的层级，防止组合使用时互相遮挡
2、移除`Modal`组件的`width`参数，可在组件上通过`style/class`设置宽度
3、移除`Modal`组件的`top`参数，规范中不涉及距离顶部偏移量