### PR TITLE
test(editable-select): 增加对allow-clear属性的测试

### DIFF
--- a/packages/devui-vue/devui/editable-select/__tests__/editable-select.spec.ts
+++ b/packages/devui-vue/devui/editable-select/__tests__/editable-select.spec.ts
@@ -315,5 +315,47 @@ describe('editable-select test', () => {
     expect(wrapper.vm.value).toBe('2');
   });
 
-  it.todo('props allow-clear work well.');
+  test('allow-clear', async () => {
+    const wrapper = mount({
+      components: {
+        'editable-select': EditableSelect,
+      },
+      template: `<editable-select v-model="value" :options="options"></editable-select>`,
+      setup() {
+        const value = ref('');
+        const options = createData();
+        return {
+          value,
+          options,
+        };
+      },
+    });
+
+    const input = wrapper.find('input');
+    await input.trigger('click');
+
+    const flexibleOverlay = wrapper.getComponent({ name: 'DFlexibleOverlay' });
+
+    const options = flexibleOverlay.findAll(`.devui-dropdown-item`);
+
+    await options[0].trigger('click');
+
+    expect(wrapper.find('input').element.value).toBe('label0');
+    expect(wrapper.vm.value).toBe('0');
+
+    const removeIcon = wrapper.find('.icon-remove');
+    await removeIcon.trigger('click');
+
+    expect(wrapper.find('input').element.value).toBe('');
+    expect(wrapper.vm.value).toBe('');
+
+    await options[1].trigger('click');
+    expect(wrapper.find('input').element.value).toBe('label1');
+    expect(wrapper.vm.value).toBe('1');
+
+    await removeIcon.trigger('click');
+
+    expect(wrapper.find('input').element.value).toBe('');
+    expect(wrapper.vm.value).toBe('');
+  });
 });

--- a/packages/devui-vue/devui/editable-select/__tests__/editable-select.spec.ts
+++ b/packages/devui-vue/devui/editable-select/__tests__/editable-select.spec.ts
@@ -82,6 +82,7 @@ describe('editable-select test', () => {
     await options.trigger('click');
 
     expect(wrapper.find('input').element.value).toBe('label0');
+    expect(wrapper.vm.value).toBe('0');
   });
 
   test('disabled select', async () => {
@@ -136,10 +137,12 @@ describe('editable-select test', () => {
     await options[1].trigger('click');
 
     expect(wrapper.find('input').element.value).toBe('');
+    expect(wrapper.vm.value).toBe('');
 
     await options[2].trigger('click');
 
     expect(wrapper.find('input').element.value).toBe('label2');
+    expect(wrapper.vm.value).toBe('2');
   });
 
   test('search', async () => {
@@ -309,6 +312,7 @@ describe('editable-select test', () => {
     await input.trigger('keydown', { key: 'ArrowDown' });
     await input.trigger('keydown', { key: 'Enter' });
     expect(input.element.value).toBe('label2');
+    expect(wrapper.vm.value).toBe('2');
   });
 
   it.todo('props allow-clear work well.');


### PR DESCRIPTION
测试editable-select组件的clear功能