### PR TITLE
fix(editable-select): fix #1253

### DIFF
--- a/packages/devui-vue/devui/editable-select/src/editable-select.tsx
+++ b/packages/devui-vue/devui/editable-select/src/editable-select.tsx
@@ -113,6 +113,7 @@ export default defineComponent({
 
     const handleClear = () => {
       inputValue.value = '';
+      ctx.emit('update:modelValue', '');
     };
 
     const getItemCls = (option: OptionObjectItem, index: number) => {


### PR DESCRIPTION
修复clear不会触发清空绑定值的bug