### PR TITLE
fix: 修复 #1300 #1274 #1062 #1303

### DIFF
--- a/packages/devui-vue/devui/mention/src/mention.tsx
+++ b/packages/devui-vue/devui/mention/src/mention.tsx
@@ -63,7 +63,7 @@ export default defineComponent({
       e.stopPropagation();
       e.preventDefault();
       showSuggestions.value = false;
-      textContext.value += item[props.dmValueParse.value as keyof IMentionSuggestionItem];
+      textContext.value = textContext.value.substring(0, 1) + item[props.dmValueParse.value as keyof IMentionSuggestionItem];
     };
 
     const arrowKeyDown = (e: KeyboardEvent) => {
@@ -98,7 +98,9 @@ export default defineComponent({
           e.stopPropagation();
           e.preventDefault();
           showSuggestions.value = false;
-          textContext.value += filteredSuggestions.value[currentIndex.value][props.dmValueParse.value as keyof IMentionSuggestionItem];
+          textContext.value =
+            textContext.value.substring(0, 1) +
+            filteredSuggestions.value[currentIndex.value][props.dmValueParse.value as keyof IMentionSuggestionItem];
           emit('select', filteredSuggestions.value[currentIndex.value]);
         }
       }

--- a/packages/devui-vue/devui/modal/src/modal.scss
+++ b/packages/devui-vue/devui/modal/src/modal.scss
@@ -45,13 +45,14 @@
     align-items: center;
 
     &-icon {
-      display: inline-block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       vertical-align: middle;
       margin-right: 8px;
       width: 24px;
       height: 24px;
       line-height: 16px;
-      text-align: center;
     }
 
     &-text {

--- a/packages/devui-vue/devui/select/src/use-select.ts
+++ b/packages/devui-vue/devui/select/src/use-select.ts
@@ -131,7 +131,7 @@ export default function useSelect(
         const newOption = {
           name: value,
           value: value,
-          _checked: false,
+          _checked: true,
         };
         return value ? newOption : option;
       } else {
@@ -236,7 +236,7 @@ export default function useSelect(
   const tagDelete = (data: OptionObjectItem) => {
     let { modelValue } = props;
     const checkedItems = [];
-    for (const child of injectOptions.value.values()) {
+    for (const child of selectedOptions.value) {
       if (data.value === child.value) {
         child._checked = false;
       }

--- a/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.scss
+++ b/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.scss
@@ -295,6 +295,7 @@ $devui-tab-slider-bg: $devui-list-item-hover-bg;
   padding-left: 0;
   overflow-y: hidden;
   overflow-x: scroll;
+  user-select: none;
   // 隐藏滚动条
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.scss
+++ b/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.scss
@@ -293,6 +293,15 @@ $devui-tab-slider-bg: $devui-list-item-hover-bg;
   align-items: center;
   list-style: none;
   padding-left: 0;
+  overflow-y: hidden;
+  overflow-x: scroll;
+  // 隐藏滚动条
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   li {
     a {

--- a/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.tsx
+++ b/packages/devui-vue/devui/tabs/src/components/tab-nav/tab-nav.tsx
@@ -1,4 +1,16 @@
-import { computed, defineComponent, inject, onBeforeMount, onMounted, onUpdated, reactive, SetupContext, shallowRef, watch } from 'vue';
+import {
+  computed,
+  defineComponent,
+  inject,
+  onBeforeMount,
+  onMounted,
+  onUpdated,
+  reactive,
+  SetupContext,
+  shallowRef,
+  watch,
+  nextTick,
+} from 'vue';
 import { TabsData, tabsProps, TabsProps, TabsStateData } from '../../tabs-types';
 import { useNamespace } from '../../../../shared/hooks/use-namespace';
 import { useTabNavRender } from './composables/use-tab-nav-render';
@@ -35,6 +47,16 @@ export default defineComponent({
       }
     );
 
+    const handleTabAdd = () => {
+      onTabAdd();
+      nextTick(() => {
+        // 使每次添加新tab后，滚动条都在最右侧
+        if (tabsEle.value) {
+          tabsEle.value.scrollLeft = tabsEle.value.scrollWidth;
+        }
+      });
+    };
+
     return () => {
       const closeIconEl = (item: TabsStateData) => {
         return tabCanClose(item) ? (
@@ -44,7 +66,7 @@ export default defineComponent({
         ) : null;
       };
       const newButton = props.addable ? (
-        <li class={ns.e('new-tab')} onClick={onTabAdd}>
+        <li class={ns.e('new-tab')} onClick={handleTabAdd}>
           <d-icon name="add"></d-icon>
         </li>
       ) : null;


### PR DESCRIPTION
1. [fix(modal): 修复dialog的个第一个icon和其他的不对齐](https://github.com/DevCloudFE/vue-devui/pull/1301/commits/e285f720878a1217fa2c1a7e6a1e713d196f1ba2)https://github.com/DevCloudFE/vue-devui/issues/1300

使用flex布局修复icon不对齐问题
<img width="972" alt="image" src="https://user-images.githubusercontent.com/34366225/188305227-49adce77-90e1-48a6-9260-06d69ea63139.png">

2. [修复select新增选项，删除一个，其他新增的选项全部被删除了](https://github.com/DevCloudFE/vue-devui/pull/1301/commits/5390d0bca6a0fdb1ebde2420c261b8d747f48f19) https://github.com/DevCloudFE/vue-devui/issues/1274

![2022-09-04 17 18 40](https://user-images.githubusercontent.com/34366225/188306699-c827437a-fd4a-4efa-a959-59e8ee0e3512.gif)

3. [fix(tabs): 修复Tabs溢出不截断](https://github.com/DevCloudFE/vue-devui/pull/1301/commits/219d0e15d179776228c65a37fc6e93222ddbbd1b) https://github.com/DevCloudFE/vue-devui/issues/1062

使多个tabs溢出可以滑动
![2022-09-04 17 28 49](https://user-images.githubusercontent.com/34366225/188306875-1622e52b-6ab5-4b58-b77b-b0e5d69795bd.gif)

4. [fix(mention): 修复Mention 组件的联想文字选中后应替换触发输入的联想文本，而非追加](https://github.com/DevCloudFE/vue-devui/pull/1301/commits/f3ef2b64008ea8435b0e8d6fe22d3d5403385fc6) https://github.com/DevCloudFE/vue-devui/issues/1303

修复后效果

![2022-09-05 11 38 19](https://user-images.githubusercontent.com/34366225/188356132-13ef09b1-7b9b-4ddc-a2bd-4ea55e23fae3.gif)

点击的话好像也有问题，但我在其他pr中看到有小伙伴修复了😄





