### PR TITLE
fix(checkbox): #1323 修复checkboxGroup下，组件底部遮挡问题

### DIFF
--- a/packages/devui-vue/devui/checkbox/src/checkbox.scss
+++ b/packages/devui-vue/devui/checkbox/src/checkbox.scss
@@ -180,7 +180,8 @@ $checkbox-label-height-map: (
     cursor: pointer;
     color: $devui-text;
     margin: 0;
-    display: block;
+    display: flex;
+    align-items: center;
     @each $size in ('lg', 'md', 'sm') {
       &.#{$devui-prefix}-checkbox--#{$size} {
         display: flex;
@@ -213,7 +214,19 @@ $checkbox-label-height-map: (
       display: inline-block;
       box-sizing: content-box;
       vertical-align: top;
+
+      &.#{$devui-prefix}-checkbox__material {
+        flex-shrink: 0; // keep the checkbox icon width
+      }
+
+      &.#{$devui-prefix}-checkbox__label-text {
+        flex-shrink: 1; // just use flex box to shrink text width. let text ellipsis
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
+
   }
 
   // 禁用状态透明色

--- a/packages/devui-vue/devui/checkbox/src/checkbox.tsx
+++ b/packages/devui-vue/devui/checkbox/src/checkbox.tsx
@@ -89,7 +89,7 @@ export default defineComponent({
                   </g>
                 </svg>
               </span>
-              {props.label || ctx.slots.default?.()}
+              <span class={ns.e('label-text')}>{props.label || ctx.slots.default?.()}</span>
             </label>
           </div>
         </div>

--- a/packages/devui-vue/devui/transfer/__tests__/transfer.spec.ts
+++ b/packages/devui-vue/devui/transfer/__tests__/transfer.spec.ts
@@ -223,7 +223,10 @@ describe('d-transfer', () => {
       setTimeout(resolve, 500);
     });
     const firstCheckbox = wrapper.find(`${sourceClass} ${bodyClass} .devui-checkbox`);
-    expect(firstCheckbox.text()).toBe('北京北京');
-    expect(firstCheckbox.findAll('span')[2].attributes().style).toBe('color: rgb(94, 124, 224);');
+    const firstCheckboxTextLabel = firstCheckbox.find('.devui-checkbox__label-text span'); // the text element
+    expect(firstCheckboxTextLabel.text()).toBe('北京北京');
+
+    // check the checkbox props —— renderContent: h('span', { style: { color: '#5e7ce0' } }, [option.value, option.name])
+    expect(firstCheckboxTextLabel.attributes().style).toBe('color: rgb(94, 124, 224);');
   });
 });


### PR DESCRIPTION
# 修复过程

## 问题原因

在部分浏览器的渲染下 checkbox icon 会向下偏移1px，就拿文档例子说，16px盒子大小，checkbox icon也为 16 * 16，向下偏移1px，且最外部容器在分组（group）下，会添加`overflow： hidden;` 样式 【`.devui-checkbox__wrap .devui-checkbox label`】，所以呈现的就是显示不全的情况。

> 兼容性Tips：目前在Windows下能够复现，Mac下Chrome无法复现（104.0），maybe 新版本修复了这个向下偏移的问题？

## 修复思路

既然正常默认文档流的情况，checkbox - icon 在部分情况会向下偏移1px，那么我们让他不偏移即可。

这里我们将外部容器 label，修改为flex（原为block），并令子元素始终垂直居中 `align-items: center;` 即可。

- 其他带来问题修复：

    - 原来的label文字是直接作为文字标签放到label中的，所以在label上设置的ellipsis是有效的，但label改为flex后，内部文字标签，会遵循弹性和模型子元素规则， 长度超过时会造成长度溢出。这里我们需要对文字标签进一步设置。
    - 1. 将文字标签用span包裹起来（主要取个名字好设置css），设置css `flex-shrink: 1;` 令其会自动按照父级flex盒子大小缩减。
    - 2. 同时要同步为 checkbox icon 标签设置样式 `flex-shrink: 0;` 让它不参与缩减，否则会被文字标签挤占宽度导致坍缩。

## 修复效果：

1. checkbox分组：
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/22699218/190188446-3bb11034-8f88-48e4-ae91-5dc0651f414e.png">


2. 其他checkbox情况（未受影响）：
<img width="918" alt="image" src="https://user-images.githubusercontent.com/22699218/190188546-c136ee69-7647-4a56-8ed1-29ffeaf9a108.png">
<img width="954" alt="image" src="https://user-images.githubusercontent.com/22699218/190188630-ab300128-e14e-4139-8feb-4859ebd2e488.png">
<img width="923" alt="image" src="https://user-images.githubusercontent.com/22699218/190188675-c26cc033-4964-4de7-819f-56b9dd5b139e.png">
<img width="940" alt="image" src="https://user-images.githubusercontent.com/22699218/190188766-0cde0e2a-a1e1-4bb7-8339-68bca0f64ea4.png">


