### PR TITLE
[WIP]refactor: extract component props to api.ts

### DIFF
--- a/packages/devui-vue/devui/button/src/api.ts
+++ b/packages/devui-vue/devui/button/src/api.ts
@@ -1,0 +1,50 @@
+import { PropType } from 'vue';
+import { IButtonColor, IButtonShape, IButtonSize, IButtonVariant } from './button-types';
+
+export const buttonProps = {
+  variant: {
+    type: String as PropType<IButtonVariant>,
+    typeName: 'IButtonVariant',
+    default: 'outline',
+    desc: '按钮形态',
+    demo: '形态',
+  },
+  color: {
+    type: String as PropType<IButtonColor>,
+    typeName: 'IButtonColor',
+    defaultName: 'secondary',
+    desc: '按钮主题',
+    demo: '主题色',
+  },
+  size: {
+    type: String as PropType<IButtonSize>,
+    typeName: 'IButtonSize',
+    default: 'md',
+    desc: '按钮尺寸',
+    demo: '尺寸',
+  },
+  icon: {
+    type: String,
+    default: '',
+    desc: '	自定义按钮图标',
+    demo: '图标按钮',
+  },
+  shape: {
+    type: String as PropType<IButtonShape>,
+    typeName: 'IButtonShape',
+    desc: '按钮形状(圆形/圆角)',
+    demo: '图标按钮',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+    desc: '是否禁用',
+    demo: '禁用状态',
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+    desc: '设置加载中状态',
+    demo: '加载中状态',
+  },
+} as const;

--- a/packages/devui-vue/devui/button/src/button-types.ts
+++ b/packages/devui-vue/devui/button/src/button-types.ts
@@ -1,38 +1,10 @@
 import type { ComputedRef, ExtractPropTypes, PropType ,InjectionKey, Ref } from 'vue';
+import { buttonProps } from './api';
 
 export type IButtonVariant = 'solid' | 'outline' | 'text';
 export type IButtonColor = 'secondary' | 'primary' | 'danger';
 export type IButtonSize = 'lg' | 'md' | 'sm';
 export type IButtonShape = 'round' | 'circle';
-
-export const buttonProps = {
-  variant: {
-    type: String as PropType<IButtonVariant>,
-    default: 'outline',
-  },
-  size: {
-    type: String as PropType<IButtonSize>,
-    default: 'md',
-  },
-  color: {
-    type: String as PropType<IButtonColor>,
-  },
-  icon: {
-    type: String,
-    default: '',
-  },
-  loading: {
-    type: Boolean,
-    default: false,
-  },
-  disabled: {
-    type: Boolean,
-    default: false,
-  },
-  shape: {
-    type: String as PropType<IButtonShape>,
-  }
-} as const;
 
 export const buttonGroupProps = {
   size: {

--- a/packages/devui-vue/devui/button/src/button.tsx
+++ b/packages/devui-vue/devui/button/src/button.tsx
@@ -2,7 +2,8 @@ import { defineComponent, toRefs } from 'vue';
 import type { SetupContext } from 'vue';
 import { Icon } from '../../icon';
 import LoadingDirective from '../../loading/src/loading-directive';
-import { buttonProps, ButtonProps } from './button-types';
+import { buttonProps } from './api';
+import { ButtonProps } from './button-types';
 import useButton from './use-button';
 import './button.scss';
 

--- a/packages/devui-vue/docs/.vitepress/theme/index.ts
+++ b/packages/devui-vue/docs/.vitepress/theme/index.ts
@@ -4,10 +4,12 @@ import Theme from '../devui-theme'
 import 'vitepress-theme-demoblock/theme/styles/index.css'
 import { registerComponents } from './register-components.js'
 import { insertBaiduScript } from './insert-baidu-script'
+import ComponentApi from '../../components/api'
 
 export default {
   ...Theme,
   enhanceApp({ app }) {
+    app.component(ComponentApi.name, ComponentApi)
     app.use(Locale).use(DevUI)
     registerComponents(app)
     insertBaiduScript()

--- a/packages/devui-vue/docs/components/api.tsx
+++ b/packages/devui-vue/docs/components/api.tsx
@@ -1,0 +1,79 @@
+import { defineComponent, toRefs } from 'vue';
+import { buttonProps } from '../../devui/button/src/api';
+
+export default defineComponent({
+  name: 'DComponentApi',
+  props: {
+    data: {
+      type: Object,
+      default: buttonProps,
+    },
+    name: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(props) {
+    const { data } = toRefs(props);
+
+    return () => {
+      return (
+        <table>
+          <thead>
+            <tr>
+              <th style="text-align:left;">
+                参数名
+              </th>
+              <th style="text-align:left;">
+                类型
+              </th>
+              <th style="text-align:left;">
+                默认
+              </th>
+              <th style="text-align:left;">
+                说明
+              </th>
+              <th style="text-align:left;">
+                跳转 Demo
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              Object.entries(data.value).map(([key, value]) => {
+                return (
+                  <tr>
+                    <td style="text-align:left;">{ key }</td>
+                    <td style="text-align:left;">
+                      {
+                        value.typeName
+                          ? <a href={`#${value.typeName.toLowerCase()}`}>
+                            { value.typeName }
+                          </a>
+                          : <code>{ value.type.name }</code>
+                      }
+                    </td>
+                    <td style="text-align:left;">
+                      {
+                        value.defaultName || (typeof value.default === 'boolean' ? String(value.default) : value.default) || '--'
+                      }
+                    </td>
+                    <td style="text-align:left;">{ value.required ? '必选' : '可选'}，{ value.desc }</td>
+                    <td style="text-align:left;">
+                      {
+                        value.demo
+                        && <a href={`#${value.demo}`}>
+                          { value.demo }
+                        </a>
+                      }
+                    </td>
+                  </tr>
+                );
+              })
+            }
+          </tbody>
+        </table>
+      );
+    };
+  },
+});

--- a/packages/devui-vue/docs/components/button/index.md
+++ b/packages/devui-vue/docs/components/button/index.md
@@ -230,15 +230,7 @@ export default defineComponent({
 
 ### Button 参数
 
-| 参数名   | 类型                              | 默认        | 说明                      | 跳转 Demo                 |
-| :------- | :-------------------------------- | :---------- | :------------------------ | :------------------------ |
-| variant  | [IButtonVariant](#ibuttonvariant) | 'outline'   | 可选，按钮形态            | [形态](#形态)             |
-| color    | [IButtonColor](#ibuttoncolor)     | 'secondary' | 可选，按钮主题            | [主题色](#主题色)         |
-| size     | [IButtonSize](#ibuttonsize)       | 'md'        | 可选，按钮尺寸            | [尺寸](#尺寸)             |
-| icon     | `string`                          | --          | 可选，自定义按钮图标      | [图标按钮](#图标按钮)     |
-| shape    | [IButtonShape](#ibuttonshape)     | --          | 可选，按钮形状(圆形/圆角) | [图标按钮](#图标按钮)     |
-| disabled | `boolean`                         | false       | 可选，是否禁用 button     | [禁用状态](#禁用状态)     |
-| loading  | `boolean`                         | false       | 可选，设置加载中状态      | [加载中状态](#加载中状态) |
+<d-component-api name="button"></d-component-api>
 
 ### Button 类型定义
 


### PR DESCRIPTION
将组件的`props`抽离到单独的`api.ts`文件中，组件文档中的 api 部分通过`api.ts`文件自动生成。

效果如下（和手动写的效果几乎一样）：

![image](https://user-images.githubusercontent.com/9566362/191302026-1ce47c08-406b-4a3c-877b-bca5656ba42d.png)
