### PR TITLE
文档更新

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Vue DevUI 使用 `pnpm` 构建 `monorepo` 仓库，你应该使用 [pnpm 6.x](ht
 2. Clone 个人空间项目到本地：`git clone git@github.com:username/vue-devui.git`
 3. 在 Vue DevUI 的根目录下运行`pnpm i`, 安装 node 依赖
 4. 运行 `pnpm dev`，启动组件库网站
-5. 使用浏览器访问：[http://localhost:3000/](http://localhost:3000/)
+5. 使用浏览器访问：`http://localhost:3000/`
 
 ```bash
 # username 为用户名，执行前请替换
@@ -30,7 +30,7 @@ Vue DevUI 是一个多人合作的开源项目，为了避免多人同时开发�
 
 > 提交之前需要给Commit添加GPG签名，参考：https://insights.thoughtworks.cn/how-to-sign-git-commit/
 
-1. 请确保你已经完成快速上手中的步骤，并且正常访问 [http://localhost:3000/](http://localhost:3000/)
+1. 请确保你已经完成快速上手中的步骤，并且正常访问 `http://localhost:3000/`
 2. 创建新分支 `git checkout -b username/feature1`，分支名字建议为`username/feat-xxx`/`username/fix-xxx`
 3. 本地编码，需遵循 [开发规范](/contributing/development-specification/)
 4. 遵循 [Angular Commit Message Format](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) 进行提交（**不符合规范的提交将不会被合并**）

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pnpm install
 pnpm dev
 ```
 
-Open your browser and visit: [http://localhost:3000/](http://localhost:3000/).
+Open your browser and visit: `http://localhost:3000/`.
 
 Or you can run other command
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ pnpm i
 pnpm dev
 ```
 
-打开浏览器访问：[http://localhost:3000/](http://localhost:3000/)
+打开浏览器访问：`http://localhost:3000/`
 
 或者你也可以运行以下命令：
 

--- a/packages/devui-vue/devui-cli/templates/vitepress-sidebar.js
+++ b/packages/devui-vue/devui-cli/templates/vitepress-sidebar.js
@@ -13,8 +13,8 @@ const { isReadyToRelease } = require('../shared/utils');
 //   return { text, link: `/${SITES_COMPONENTS_DIR_NAME}/${kebabCase(name)}/`, status }
 // }
 
-function buildCategoryOptions(text, children = []) {
-  return { text, children };
+function buildCategoryOptions(text, items = []) {
+  return { text, items };
 }
 
 function generateZhMenus(componentsInfo) {
@@ -54,16 +54,21 @@ exports.createVitepressSidebarTemplates = (componentsInfo = []) => {
     {
       rootItems: [
         {
-          text: '快速开始',
-          link: '/quick-start/',
-        },
-        {
-          text: '按需引入',
-          link: '/on-demand/',
-        },
-        {
-          text: '主题定制',
-          link: '/theme-guide/',
+          text: '开始',
+          items: [
+            {
+              text: '快速开始',
+              link: '/quick-start/',
+            },
+            {
+              text: '按需引入',
+              link: '/on-demand/',
+            },
+            {
+              text: '主题定制',
+              link: '/theme-guide/',
+            },
+          ],
         },
       ],
       handler: generateZhMenus,
@@ -72,16 +77,21 @@ exports.createVitepressSidebarTemplates = (componentsInfo = []) => {
     {
       rootItems: [
         {
-          text: 'Quick Start',
-          link: '/en-US/quick-start/',
-        },
-        {
-          text: 'On-demand Import',
-          link: '/on-demand/',
-        },
-        {
-          text: 'Theme Guide',
-          link: '/theme-guide/',
+          text: 'Start',
+          items: [
+            {
+              text: 'Quick Start',
+              link: '/en-US/quick-start/',
+            },
+            {
+              text: 'On-demand Import',
+              link: '/on-demand/',
+            },
+            {
+              text: 'Theme Guide',
+              link: '/theme-guide/',
+            },
+          ],
         },
       ],
       handler: generateEnMenus,

--- a/packages/devui-vue/devui/button/src/use-button.ts
+++ b/packages/devui-vue/devui/button/src/use-button.ts
@@ -2,7 +2,7 @@ import { computed, inject } from 'vue';
 import type { SetupContext } from 'vue';
 import { ButtonProps, UseButtonReturnType, buttonGroupInjectionKey } from './button-types';
 import { useNamespace } from '../../shared/hooks/use-namespace';
-import { isString } from 'lodash';
+import { isString } from 'lodash-es';
 
 export default function useButton(props: ButtonProps, ctx: SetupContext): UseButtonReturnType {
   const ns = useNamespace('button');

--- a/packages/devui-vue/devui/cascader/hooks/use-cascader-item.ts
+++ b/packages/devui-vue/devui/cascader/hooks/use-cascader-item.ts
@@ -1,7 +1,7 @@
 /**
  * 处理cascader-item中需要的参数
  */
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { ref, reactive, Ref } from 'vue';
 import { CascaderProps, UseCascaderItemCallback, CascaderItem } from '../src/cascader-types';
 

--- a/packages/devui-vue/devui/cascader/hooks/use-cascader.ts
+++ b/packages/devui-vue/devui/cascader/hooks/use-cascader.ts
@@ -1,5 +1,5 @@
 import { ref, SetupContext, toRef, reactive, Ref, watch, onMounted } from 'vue';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { initActiveIndexs, initSingleIptValue } from './use-cascader-single';
 import { initMultipleCascaderItem, initTagList, getMultiModelValues } from './use-cascader-multiple';
 import type { CascaderItem, CascaderValueType, CascaderProps, UseCascaderFn } from '../src/cascader-types';

--- a/packages/devui-vue/devui/cascader/hooks/use-filter.ts
+++ b/packages/devui-vue/devui/cascader/hooks/use-filter.ts
@@ -1,4 +1,4 @@
-import { debounce, cloneDeep } from 'lodash';
+import { debounce, cloneDeep } from 'lodash-es';
 import { ref, SetupContext, UnwrapRef, Ref, watch } from 'vue';
 import { initActiveIndexs } from './use-cascader-single';
 import {

--- a/packages/devui-vue/devui/cascader/src/cascader.tsx
+++ b/packages/devui-vue/devui/cascader/src/cascader.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, Transition, SetupContext, provide, Teleport } from 'vue';
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 import DCascaderList from '../components/cascader-list';
 import DMultipleBox from '../components/cascader-multiple/index';

--- a/packages/devui-vue/devui/color-picker/src/components/color-history/color-history.tsx
+++ b/packages/devui-vue/devui/color-picker/src/components/color-history/color-history.tsx
@@ -4,7 +4,7 @@ import { Icon } from '../../../../icon';
 import './color-history.scss';
 import { fromHexa } from '../../utils/color-utils';
 import { ProvideColorOptions, ColorPickerColor } from '../../utils/color-utils-types';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 const STORAGE_KEY = 'STORAGE_COLOR_PICKER_HISTORY_KEY';
 const MAX_HISOTRY_COUNT = 8;

--- a/packages/devui-vue/devui/date-picker-pro/src/composables/use-calendar-panel.ts
+++ b/packages/devui-vue/devui/date-picker-pro/src/composables/use-calendar-panel.ts
@@ -4,7 +4,7 @@ import { DAY_DURATION, calendarItemHeight } from '../const';
 import { CalendarDateItem, YearAndMonthItem, UseCalendarPanelReturnType, DatePickerProPanelProps } from '../date-picker-pro-types';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import useCalendarSelected from './use-calendar-selected';
 
 export default function useCalendarPanel(props: DatePickerProPanelProps, ctx: SetupContext): UseCalendarPanelReturnType {

--- a/packages/devui-vue/devui/date-picker-pro/src/composables/use-month-calendar-panel.ts
+++ b/packages/devui-vue/devui/date-picker-pro/src/composables/use-month-calendar-panel.ts
@@ -3,7 +3,7 @@ import type { SetupContext } from 'vue';
 import { useNamespace } from '../../../shared/hooks/use-namespace';
 import { monthCalendarItemHeight } from '../const';
 import { DatePickerProPanelProps, YearAndMonthItem, UseMonthCalendarPanelReturnType } from '../date-picker-pro-types';
-import { throttle } from 'lodash';
+import { throttle } from 'lodash-es';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import useCalendarSelected from './use-calendar-selected';

--- a/packages/devui-vue/devui/date-picker-pro/src/composables/use-year-calendar-panel.ts
+++ b/packages/devui-vue/devui/date-picker-pro/src/composables/use-year-calendar-panel.ts
@@ -1,6 +1,6 @@
 import { ref, onBeforeMount, nextTick, watch } from 'vue';
 import type { SetupContext } from 'vue';
-import { chunk } from 'lodash';
+import { chunk } from 'lodash-es';
 import { useNamespace } from '../../../shared/hooks/use-namespace';
 import { DatePickerProPanelProps, UseYearCalendarPanelReturnType } from '../date-picker-pro-types';
 import dayjs from 'dayjs';

--- a/packages/devui-vue/devui/form/src/components/form-item/use-form-item.ts
+++ b/packages/devui-vue/devui/form/src/components/form-item/use-form-item.ts
@@ -1,5 +1,5 @@
 import { computed, inject, nextTick, onMounted, ref } from 'vue';
-import { castArray, get, isFunction, clone, isEqual, set } from 'lodash';
+import { castArray, get, isFunction, clone, isEqual, set } from 'lodash-es';
 import Schema from 'async-validator';
 import type { ComputedRef, Ref } from 'vue';
 import type { RuleItem } from 'async-validator';

--- a/packages/devui-vue/devui/form/src/composables/use-form-validation.ts
+++ b/packages/devui-vue/devui/form/src/composables/use-form-validation.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import { castArray } from 'lodash-es';
 import type { ValidateFieldsError } from 'async-validator';
 import { UseFormValidation } from '../form-types';
 import { FormItemContext, FormValidateCallback, FormValidateResult } from '../components/form-item/form-item-types';

--- a/packages/devui-vue/devui/mention/src/mention.tsx
+++ b/packages/devui-vue/devui/mention/src/mention.tsx
@@ -4,7 +4,7 @@ import DTextarea from '../../textarea/src/textarea';
 import DIcon from '../../icon/src/icon';
 import './mention.scss';
 import { useNamespace } from '../../shared/hooks/use-namespace';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 export default defineComponent({
   name: 'DMention',

--- a/packages/devui-vue/devui/popover/src/use-popover.ts
+++ b/packages/devui-vue/devui/popover/src/use-popover.ts
@@ -1,6 +1,6 @@
 import { toRefs, ref, computed, watch, onUnmounted, onMounted } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { PopoverProps, UsePopoverEvent } from './popover-types';
 
 const TransformOriginMap: Record<string, string> = {

--- a/packages/devui-vue/devui/quadrant-diagram/src/components/axis/index.tsx
+++ b/packages/devui-vue/devui/quadrant-diagram/src/components/axis/index.tsx
@@ -2,7 +2,7 @@ import { defineComponent, toRefs, onMounted, reactive, ref, watch } from 'vue';
 import { IAxisConfigs, IViewConfigs } from '../../../type';
 import { AXIS_TITLE_SPACE } from '../../../config';
 import { quadrantDiagramAxisProps, QuadrantDiagramAxisProps } from './types';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 import './index.scss';
 

--- a/packages/devui-vue/devui/search/src/composables/use-search-keydown.ts
+++ b/packages/devui-vue/devui/search/src/composables/use-search-keydown.ts
@@ -3,7 +3,7 @@
  */
 import { SetupContext, Ref } from 'vue';
 import { KeydownReturnTypes, SearchProps } from '../search-types';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 type EmitProps = 'update:modelValue' | 'search';
 

--- a/packages/devui-vue/devui/select/src/composables/use-select-content.ts
+++ b/packages/devui-vue/devui/select/src/composables/use-select-content.ts
@@ -4,7 +4,7 @@ import { FORM_ITEM_TOKEN } from '../../../form';
 import { OptionObjectItem, UseSelectContentReturnType } from '../select-types';
 import { useNamespace } from '../../../shared/hooks/use-namespace';
 import { className } from '../utils';
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 import { createI18nTranslate } from '../../../locale/create';
 
 export default function useSelectContent(): UseSelectContentReturnType {

--- a/packages/devui-vue/devui/select/src/use-select.ts
+++ b/packages/devui-vue/devui/select/src/use-select.ts
@@ -4,7 +4,7 @@ import { SelectProps, OptionObjectItem, UseSelectReturnType } from './select-typ
 import { className, KeyType } from './utils';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 import { onClickOutside } from '@vueuse/core';
-import { isFunction, debounce } from 'lodash';
+import { isFunction, debounce } from 'lodash-es';
 import { FORM_ITEM_TOKEN, FORM_TOKEN } from '../../form';
 
 export default function useSelect(

--- a/packages/devui-vue/devui/textarea/src/composables/use-textarea-autosize.ts
+++ b/packages/devui-vue/devui/textarea/src/composables/use-textarea-autosize.ts
@@ -1,7 +1,7 @@
 import { computed, ShallowRef, shallowRef } from 'vue';
 import { TextareaProps, UseTextareaAutosize } from '../textarea-types';
 import type { StyleValue } from 'vue';
-import { isObject } from 'lodash';
+import { isObject } from 'lodash-es';
 import { computeTextareaHeight } from '../utils';
 
 export function useTextareaAutosize(props: TextareaProps, textarea: ShallowRef<HTMLTextAreaElement | undefined>): UseTextareaAutosize {

--- a/packages/devui-vue/devui/textarea/src/utils.ts
+++ b/packages/devui-vue/devui/textarea/src/utils.ts
@@ -1,4 +1,4 @@
-import { isNumber } from 'lodash';
+import { isNumber } from 'lodash-es';
 
 let tempTextarea: HTMLTextAreaElement | undefined = undefined;
 

--- a/packages/devui-vue/devui/tooltip/src/use-tooltip.ts
+++ b/packages/devui-vue/devui/tooltip/src/use-tooltip.ts
@@ -1,6 +1,6 @@
 import { onMounted, ref, toRefs, computed, watch } from 'vue';
 import type { Ref } from 'vue';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { TooltipProps, BasePlacement, UseTooltipFn } from './tooltip-types';
 
 export const transformOriginMap: Record<BasePlacement, string> = {

--- a/packages/devui-vue/devui/tree/src/composables/use-dragdrop.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-dragdrop.ts
@@ -2,7 +2,7 @@ import { reactive, computed } from 'vue';
 import type { Ref } from 'vue';
 import type { TreeProps } from '../tree-types';
 import type { DragState, IUseDraggable, IDropNode, IInnerTreeNode, ITreeNode, IDropType } from './use-tree-types';
-import cloneDeep from 'lodash/cloneDeep';
+import {cloneDeep} from 'lodash-es';
 import { useNamespace } from '../../../shared/hooks/use-namespace';
 import { formatBasicTree } from '../utils';
 const ns = useNamespace('tree');

--- a/packages/devui-vue/devui/tree/src/composables/use-search-filter.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-search-filter.ts
@@ -1,6 +1,6 @@
 import { Ref, ref } from 'vue';
 import { IInnerTreeNode, IUseCore, IUseSearchFilter, SearchFilterOption } from './use-tree-types';
-import { trim } from 'lodash';
+import { trim } from 'lodash-es';
 export function useSearchFilter() {
   return function useSearchFilterFn(data: Ref<IInnerTreeNode[]>, core: IUseCore): IUseSearchFilter {
     const { clearNodeMap, getExpendedTree } = core;

--- a/packages/devui-vue/docs/.vitepress/config/index.ts
+++ b/packages/devui-vue/docs/.vitepress/config/index.ts
@@ -6,6 +6,7 @@ import markdown from './markdown'
 import lang from './lang'
 
 const config = defineConfig({
+  base: '/',
   title: 'Vue DevUI',
   description: 'Vue DevUI 组件库',
   head,
@@ -34,6 +35,10 @@ const config = defineConfig({
         lang: 'en-US',
         label: 'English'
       }
+    },
+    footer: {
+      message: 'MIT Licensed',
+      copyright: 'Copyright © 2021-present DevUI'
     }
   }
 })

--- a/packages/devui-vue/docs/.vitepress/config/index.ts
+++ b/packages/devui-vue/docs/.vitepress/config/index.ts
@@ -1,46 +1,58 @@
-import { defineConfig } from 'vitepress'
-import sidebar from './sidebar'
-import head from './head'
-import nav from './nav'
-import markdown from './markdown'
-import lang from './lang'
+import { defineConfig } from 'vitepress';
+import sidebar from './sidebar';
+import head from './head';
+import nav from './nav';
+import markdown from './markdown';
+import lang from './lang';
 
 const config = defineConfig({
   base: '/',
   title: 'Vue DevUI',
   description: 'Vue DevUI 组件库',
+  appearance: false, // 是否启用暗模式
   head,
   markdown,
   locales: {
     '/': {
       lang: 'zh-CN',
-      label: '简体中文'
+      label: '简体中文',
     },
     '/en-US': {
       lang: 'en-US',
-      label: 'English'
-    }
+      label: 'English',
+    },
   },
   themeConfig: {
     sidebar,
     nav,
+    // outline: [2, 6], todo 大纲中的标题等级 新版本启用
+    outlineTitle: '快速前往',
+    algolia: {},
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/DevCloudFE/vue-devui' },
+    ],
     demoblock: lang,
     logo: '../../assets/logo.svg',
     locales: {
       '/': {
         lang: 'zh-CN',
-        label: '简体中文'
+        label: '简体中文',
       },
       '/en-US': {
         lang: 'en-US',
-        label: 'English'
-      }
+        label: 'English',
+      },
     },
     footer: {
+      // todo 新版本中启用
+      // license: {
+      //   text: 'MIT License',
+      //   link: 'https://opensource.org/licenses/MIT'
+      // },
       message: 'MIT Licensed',
-      copyright: 'Copyright © 2021-present DevUI'
-    }
-  }
-})
+      copyright: `Copyright © 2021-${new Date().getFullYear()} DevUI`,
+    },
+  },
+});
 
-export default config
+export default config;

--- a/packages/devui-vue/docs/.vitepress/theme/components/Contributors.vue
+++ b/packages/devui-vue/docs/.vitepress/theme/components/Contributors.vue
@@ -1,0 +1,144 @@
+<script setup>
+import PageContributor from './PageContributor.vue';
+import { CONTRIBUTORS_MAP } from './PageContributorConfig';
+import { computed } from 'vue';
+
+function unique(arr) {
+  let map = new Map();
+  let array = new Array();
+  for (let i = 0; i < arr.length; i++) {
+    if (map.has(arr[i].homepage)) {
+      map.set(arr[i].homepage, true);
+    } else {
+      map.set(arr[i].homepage, false);
+      array.push(arr[i]);
+    }
+  }
+  return array;
+}
+
+const contributors = computed(() => {
+  return unique(Object.values(CONTRIBUTORS_MAP).flat());
+});
+
+</script>
+
+<template>
+  <div class="container-contributors">
+    <div class="contributors-inner">
+      <h2>✨贡献者✨</h2>
+      <PageContributor
+        v-if="contributors && contributors.length > 0"
+        :contributors="contributors"
+        :spacing="20"
+        :avatarSize="48"
+      />
+      <a href="/contributing/">
+        <Button class="btn-become-contributor" variant="solid" color="primary">成为贡献者</Button>
+      </a>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+// iPad/PC
+.container-contributors {
+  padding: 2rem 0;
+  background: var(--devui-global-bg, #f3f6f8);
+
+  .contributors-inner {
+    max-width: 564px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+
+    h2 {
+      margin-top: 1rem;
+      margin-bottom: 2rem;
+      text-align: center;
+      font-size: 2rem;
+      border: 0;
+    }
+
+    img {
+      max-width: unset;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
+
+    .btn-become-contributor {
+      margin-top: 1rem;
+    }
+
+    .page-contributor {
+      padding: 0 20px;
+
+      & > a:nth-child(8n) > span {
+        margin: 0 !important;
+      }
+    }
+  }
+}
+
+// iPhone 6/7/8 Plus(414) Nexus 5X/6/6P(412)
+@media (max-width: 420px) {
+  .container-contributors .contributors-inner {
+    h2 {
+      font-size: 1.6rem;
+    }
+
+    .page-contributor {
+      & > a > span {
+        margin: 0 12px 8px 0 !important;
+
+        & > img, & svg {
+          width: 40px !important;
+          height: 40px !important;
+        }
+      }
+
+      & > a:nth-child(8n) > span {
+        margin: 0 12px 8px 0 !important;
+      }
+
+      & > a:nth-child(7n) > span {
+        margin: 0 !important;
+      }
+    }
+  }
+}
+
+// iPhone 6/7/8/X(375) Nexus 4/5(384/360)
+@media (max-width: 385px) {
+  .container-contributors .contributors-inner {
+    .page-contributor {
+      & > a:nth-child(7n) > span {
+        margin: 0 12px 8px 0 !important;
+      }
+
+      & > a:nth-child(6n) > span {
+        margin: 0 !important;
+      }
+    }
+  }
+}
+
+// iPhone 4/5/SE(320)
+@media (max-width: 330px) {
+  .container-contributors .contributors-inner {
+    .page-contributor {
+      & > a:nth-child(6n) > span {
+        margin: 0 12px 8px 0 !important;
+      }
+
+      & > a:nth-child(5n) > span {
+        margin: 0 !important;
+      }
+    }
+  }
+}
+</style>

--- a/packages/devui-vue/docs/.vitepress/theme/components/HomeFooter.vue
+++ b/packages/devui-vue/docs/.vitepress/theme/components/HomeFooter.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+
+const { frontmatter } = useData()
+</script>
+
+<template>
+  <footer v-if="frontmatter.footer" class="footer">
+    <div class="container">
+      <div class="footer-item">
+        <div class="footer-item__title">社区</div>
+        <ul>
+          <li><a href="https://github.com/DevCloudFE/vue-devui" target="_blank">代码仓库</a></li>
+          <li><a href="https://github.com/DevCloudFE/vue-devui/releases" target="_blank">更新日志</a></li>
+          <li><a href="https://github.com/DevCloudFE/vue-devui/issues" target="_blank">反馈建议</a></li>
+          <li><a href="https://juejin.cn/user/712139267650141" target="_blank">DevUI 掘金专栏</a></li>
+          <li><a href="https://www.zhihu.com/people/devui-design" target="_blank">DevUI 知乎主页</a></li>
+          <li><a href="https://segmentfault.com/u/devui" target="_blank">SegmentFault</a></li>
+        </ul>
+      </div>
+      <div class="footer-item">
+        <div class="footer-item__title">生态</div>
+        <ul>
+          <li><a href="https://devui.design/" target="_blank">Ng DevUI</a></li>
+          <li><a href="https://vue-devui.github.io/" target="_blank">Vue DevUI</a></li>
+          <li><a href="https://react-devui.surge.sh/" target="_blank">React DevUI</a></li>
+          <li><a href="https://devui.design/admin-page/home" target="_blank">Ng DevUI Admin</a></li>
+          <li><a href="https://devui.design/icon/ruleResource" target="_blank">DevUI Icons</a></li>
+          <li><a href="https://devcloudfe.github.io/devui-playground" target="_blank">DevUI Playground</a></li>
+        </ul>
+      </div>
+      <div class="footer-item">
+        <div class="footer-item__title">友链</div>
+        <ul>
+          <li><a href="http://h5.dooring.cn/" target="_blank">H5-Dooring - 让H5制作，更简单</a></li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<style scoped lang="scss">
+@import '@devui/styles-var/devui-var';
+
+.footer {
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+@media (min-width: 720px) {
+  .footer {
+    padding: 0 1.5rem;
+  }
+}
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: 2rem 1.5rem 2.25rem;
+
+  .footer-item {
+    margin-right: 20px;
+    font-size: 14px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    ul {
+      list-style: none;
+      padding-left: 0;
+
+      a {
+        color: $devui-text;
+        text-decoration: none;
+        line-height: 28px;
+
+        &:hover {
+          color: $devui-brand;
+        }
+      }
+    }
+
+    &__title {
+      font-size: 18px;
+    }
+  }
+}
+
+.home-hero + .footer .container,
+.home-features + .footer .container,
+.home-content + .footer .container {
+  /* border-top: 1px solid var(--c-divider); */
+}
+
+@media (min-width: 420px) {
+  .container {
+    padding: 3rem 1.5rem 3.25rem;
+  }
+}
+
+.text {
+  margin: 0;
+  text-align: center;
+  line-height: 1.4;
+  font-size: 0.9rem;
+  color: $devui-text-weak;
+}
+</style>

--- a/packages/devui-vue/docs/.vitepress/theme/components/HomeFooter.vue
+++ b/packages/devui-vue/docs/.vitepress/theme/components/HomeFooter.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
-import { useData } from 'vitepress'
-
-const { frontmatter } = useData()
 </script>
 
 <template>
-  <footer v-if="frontmatter.footer" class="footer">
+  <footer  class="footer">
     <div class="container">
       <div class="footer-item">
         <div class="footer-item__title">社区</div>

--- a/packages/devui-vue/docs/.vitepress/theme/components/PageContributor.vue
+++ b/packages/devui-vue/docs/.vitepress/theme/components/PageContributor.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { toRefs, computed } from 'vue';
+import { Avatar } from '@devui/avatar';
+
+interface Props {
+  contributors: Array<{
+    avatar: String;
+    homepage: String;
+  }>;
+  spacing?: number;
+  avatarSize?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  contributors: () => [],
+  spacing: 8,
+  avatarSize: 36,
+});
+
+const { contributors, spacing, avatarSize } = toRefs(props);
+
+const validContributors = computed(() => {
+  return contributors.value.filter((item) => item.avatar);
+});
+</script>
+
+<template>
+  <div class="page-contributor">
+    <a v-for="contributor of validContributors" :href="contributor.homepage" target="_blank">
+      <Avatar
+        v-if="contributor.avatar"
+        class="contributor-avatar"
+        :style="{
+          marginRight: `${spacing}px`,
+          marginBottom: `${spacing - 4}px`,
+        }"
+        :imgSrc="contributor.avatar"
+        :width="avatarSize"
+        :height="avatarSize"
+      />
+    </a>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.page-contributor {
+  display: flex;
+  flex-wrap: wrap;
+
+  .contributor-avatar {
+    margin: 0 8px 4px 0;
+  }
+}
+</style>

--- a/packages/devui-vue/docs/.vitepress/theme/components/PageContributorConfig.ts
+++ b/packages/devui-vue/docs/.vitepress/theme/components/PageContributorConfig.ts
@@ -1,0 +1,1202 @@
+interface IContributingMap {
+  [key: string]: Array<{
+    avatar: string;
+    homepage: string;
+    founder?: boolean; // 组件创建者（从0到1创建组件）
+    leader?: boolean; // 组件负责人（负责组件特性开发、缺陷修复、单元测试、文档完善）
+    core?: boolean; // 核心开发者（对组件做出重大贡献）
+  }>
+}
+
+export const CONTRIBUTORS_MAP: IContributingMap = {
+  // 通用
+  button: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/24841685?v=4',
+      homepage: 'https://github.com/qinwencheng'
+    },
+  ],
+  dragdrop: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/61737780?v=4',
+      homepage: 'https://github.com/asdlml6'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+  ],
+  fullscreen: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/20532893?v=4',
+      homepage: 'https://github.com/MICD0704'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+  ],
+  icon: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol',
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/57666140?v=4',
+      homepage: 'https://github.com/flingyp'
+    },
+  ],
+  overlay: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/10958003?v=4',
+      homepage: 'https://github.com/liuxdi'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/23261843?v=4',
+      homepage: 'https://github.com/to0simple'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/46524158?v=4',
+      homepage: 'https://github.com/wakaka378'
+    },
+  ],
+  panel: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31283122?v=4',
+      homepage: 'https://github.com/GaoNeng-wWw'
+    },
+  ],
+  ripple: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/66500121?v=4',
+      homepage: 'https://github.com/ErKeLost'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  search: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/29355875?v=4',
+      homepage: 'https://github.com/SituC'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/22699218?v=4',
+      homepage: 'https://github.com/xzxldl55'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+  ],
+  status: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/25116549?v=4',
+      homepage: 'https://github.com/LiuSuY'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  sticky: [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/maizhiyuan'
+    },
+  ],
+
+  // 导航
+  accordion: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/74694190?v=4',
+      homepage: 'https://github.com/Pineapple0919'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/10958003?v=4',
+      homepage: 'https://github.com/liuxdi'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/28033581?v=4',
+      homepage: 'https://github.com/annoyc'
+    },
+  ],
+  anchor: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/43716517?v=4',
+      homepage: 'https://github.com/Tmac2015'
+    },
+  ],
+  'back-top': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/38075730?v=4',
+      homepage: 'https://github.com/c0dedance'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/35223515?v=4',
+      homepage: 'https://github.com/LadyChatterleyLover'
+    },
+  ],
+  breadcrumb: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/28448589?v=4',
+      homepage: 'https://github.com/jecyu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/63281354?v=4',
+      homepage: 'https://github.com/angelanana'
+    },
+  ],
+  dropdown: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+  ],
+  menu: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31283122?v=4',
+      homepage: 'https://github.com/GaoNeng-wWw'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+  ],
+  'nav-sprite': [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/flxy1028'
+    },
+  ],
+  pagination: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/24663941?v=4',
+      homepage: 'https://github.com/554246839'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  steps: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'steps-guide': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/30283065?v=4?s=100',
+      homepage: 'https://github.com/NidusP'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  tabs: [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/flxy1028'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+
+  // 反馈
+  alert: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/91681351?v=4',
+      homepage: 'https://github.com/chressYu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/10958003?v=4',
+      homepage: 'https://github.com/liuxdi'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48482395?v=4',
+      homepage: 'https://github.com/GeorgeLeoo'
+    },
+  ],
+  drawer: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/15092594?v=4',
+      homepage: 'https://github.com/lnzhangsong'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/72056179?v=4',
+      homepage: 'https://github.com/aolyang'
+    },
+  ],
+  loading: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/24663941?v=4',
+      homepage: 'https://github.com/554246839'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  message: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/71202421?v=4',
+      homepage: 'https://github.com/79E'
+    },
+  ],
+  modal: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/50540342?v=4',
+      homepage: 'https://github.com/Husky-Yellow'
+    },
+  ],
+  notification: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/10958003?v=4',
+      homepage: 'https://github.com/liuxdi'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/23261843?v=4',
+      homepage: 'https://github.com/to0simple'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31283122?v=4',
+      homepage: 'https://github.com/GaoNeng-wWw'
+    },
+  ],
+  popover: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/58327088?v=4',
+      homepage: 'https://github.com/CatsAndMice'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/47918504?v=4',
+      homepage: 'https://github.com/banlify'
+    },
+  ],
+  'read-tip': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/62528887?v=4',
+      homepage: 'https://github.com/whylost'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/26707568?v=4',
+      homepage: 'https://github.com/panyongxu'
+    },
+  ],
+  result: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/27618209?v=4',
+      homepage: 'https://github.com/icjs-cc',
+      founder: true,
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+  ],
+  tooltip: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/61737780?v=4',
+      homepage: 'https://github.com/asdlml6'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/26324442?v=4',
+      homepage: 'https://github.com/zxlfly'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+  ],
+
+  // 数据录入
+  'auto-complete': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/26324442?v=4',
+      homepage: 'https://github.com/zxlfly',
+      founder: true,
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/66343210?v=4',
+      homepage: 'https://github.com/Denver-Ning'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+  ],
+  'multi-auto-complete': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/26324442?v=4',
+      homepage: 'https://github.com/zxlfly',
+      leader: true,
+    },
+  ],
+  cascader: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/29355875?v=4',
+      homepage: 'https://github.com/SituC'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+  ],
+  checkbox: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31237954?v=4',
+      homepage: 'https://github.com/brenner8023',
+      founder: true,
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/liao-jianguo'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/33192247?v=4',
+      homepage: 'https://github.com/qiugu'
+    },
+  ],
+  collapse: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'color-picker': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/66500121?v=4',
+      homepage: 'https://github.com/ErKeLost'
+    },
+  ],
+  'date-picker': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/1510444?v=4',
+      homepage: 'https://github.com/imnull'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48482395?v=4',
+      homepage: 'https://github.com/GeorgeLeoo'
+    },
+  ],
+  'date-picker-pro': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/28448589?v=4',
+      homepage: 'https://github.com/jecyu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/50767049?v=4',
+      homepage: 'https://github.com/jCodeLife'
+    },
+  ],
+  'editable-select': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40349890?v=4',
+      homepage: 'https://github.com/chenxi24',
+      founder: true,
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+  ],
+  form: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07',
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/42601044?v=4',
+      homepage: 'https://github.com/AlanLee97',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+  ],
+  input: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/29355875?v=4',
+      homepage: 'https://github.com/SituC',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe',
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48074435?v=4',
+      homepage: 'https://github.com/elsaooo'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel',
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11595706?v=4',
+      homepage: 'https://github.com/tycsbs',
+    },
+  ],
+  'input-icon': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/1510444?v=4',
+      homepage: 'https://github.com/imnull'
+    },
+  ],
+  'input-number': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/16344566?v=4',
+      homepage: 'https://github.com/git-Where',
+      founder: true,
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+  ],
+  radio: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31237954?v=4',
+      homepage: 'https://github.com/brenner8023',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/22795131?v=4',
+      homepage: 'https://github.com/xuehongjie',
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+  ],
+  select: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32935349?v=4',
+      homepage: 'https://github.com/unfound',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel',
+      core: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+  ],
+  slider: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/27467603?v=4',
+      homepage: 'https://github.com/xiaoboRao'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/54826175?v=4',
+      homepage: 'https://github.com/ming-bin'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52768159?v=4',
+      homepage: 'https://github.com/wang-zhaofei'
+    },
+  ],
+  switch: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31237954?v=4',
+      homepage: 'https://github.com/brenner8023'
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/vergil_lu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'tag-input': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/31237954?v=4',
+      homepage: 'https://github.com/brenner8023',
+      founder: true,
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/gu_yan'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  textarea: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/23047484?v=4',
+      homepage: 'https://github.com/cuiaiguanggh',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333',
+      core: true,
+    },
+  ],
+  'time-picker': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/58691226?v=4',
+      homepage: 'https://github.com/qq154239735'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'time-select': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  transfer: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/15258339?v=4',
+      homepage: 'https://github.com/ForeseeBear'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'tree-select': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/38213540?v=4',
+      homepage: 'https://github.com/254311563'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+  ],
+  upload: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48074435?v=4',
+      homepage: 'https://github.com/elsaooo'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+
+  // 数据展示
+  avatar: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48074435?v=4',
+      homepage: 'https://github.com/elsaooo'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+  ],
+  badge: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/30541930?v=4',
+      homepage: 'https://github.com/duqingyu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/20532893?v=4',
+      homepage: 'https://github.com/MICD0704'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/24841685?v=4',
+      homepage: 'https://github.com/qinwencheng'
+    },
+  ],
+  card: [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/vergil_lu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52768159?v=4',
+      homepage: 'https://github.com/wang-zhaofei'
+    },
+  ],
+  carousel: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/7751774?v=4',
+      homepage: 'https://github.com/Roading'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  comment: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40553790?v=4',
+      homepage: 'https://github.com/nextniko'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  countdown: [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/HeQinQins'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/41265413?v=4',
+      homepage: 'https://github.com/Innei'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32407134?v=4',
+      homepage: 'https://github.com/qinqinhe'
+    },
+  ],
+  dashboard: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/7751774?v=4',
+      homepage: 'https://github.com/Roading'
+    },
+  ],
+  gantt: [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/liuyingbin'
+    },
+  ],
+  'image-preview': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/30541930?v=4',
+      homepage: 'https://github.com/duqingyu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/10958003?v=4',
+      homepage: 'https://github.com/liuxdi'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+  ],
+  list: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+  ],
+  progress: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/67035714?v=4',
+      homepage: 'https://github.com/devin974'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'quadrant-diagram': [
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/nowisfuture'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  rate: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/48074435?v=4',
+      homepage: 'https://github.com/elsaooo'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/52314078?v=4',
+      homepage: 'https://github.com/vaebe'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  skeleton: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/70649502?v=4',
+      homepage: 'https://github.com/ivestszheng',
+      founder: true,
+      leader: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/15258339?v=4',
+      homepage: 'https://github.com/ForeseeBear'
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/georgeleeo_jxd'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  statistic: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/20873286?v=4',
+      homepage: 'https://github.com/17714574361'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/66500121?v=4',
+      homepage: 'https://github.com/ErKeLost'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  table: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/13329558?v=4',
+      homepage: 'https://github.com/Zcating'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/70649502?v=4',
+      homepage: 'https://github.com/ivestszheng'
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/georgeleeo_jxd'
+    },
+    {
+      avatar: '',
+      homepage: 'https://gitee.com/weban'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/22699218?v=4',
+      homepage: 'https://github.com/xzxldl55'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/22176126?v=4',
+      homepage: 'https://github.com/TerminatorSd'
+    },
+  ],
+  tag: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/38075730?v=4',
+      homepage: 'https://github.com/c0dedance'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/8649913?v=4',
+      homepage: 'https://github.com/lj1990111'
+    },
+  ],
+  timeline: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/46488783?v=4',
+      homepage: 'https://github.com/JensonMiao'
+    },
+  ],
+  tree: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/9566362?v=4',
+      homepage: 'https://github.com/kagol'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/46395105?v=4',
+      homepage: 'https://github.com/sufuwang'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/87163017?v=4',
+      homepage: 'https://github.com/faq0192'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39021499?v=4',
+      homepage: 'https://github.com/daviForevel'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/11143986?v=4',
+      homepage: 'https://github.com/xingyan95'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/32949033?v=4',
+      homepage: 'https://github.com/newer2333'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/39939976?v=4',
+      homepage: 'https://github.com/foolmadao'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/74694190?v=4',
+      homepage: 'https://github.com/NoTwoBoy'
+    },
+  ],
+  // 布局
+  grid: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/54826175?v=4',
+      homepage: 'https://github.com/ming-bin'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/76561071?v=4',
+      homepage: 'https://github.com/liyao1520'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/34124930?v=4',
+      homepage: 'https://github.com/Lonely-shang'
+    },
+  ],
+  layout: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/54833732?v=4',
+      homepage: 'https://github.com/zzztwx',
+      founder: true,
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  splitter: [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/28448589?v=4',
+      homepage: 'https://github.com/jecyu'
+    },
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+  'virtual-list': [
+    {
+      avatar: 'https://avatars.githubusercontent.com/u/40119767?v=4',
+      homepage: 'https://github.com/linxiang07'
+    },
+  ],
+}

--- a/packages/devui-vue/docs/.vitepress/theme/components/ThemePicker.vue
+++ b/packages/devui-vue/docs/.vitepress/theme/components/ThemePicker.vue
@@ -1,0 +1,154 @@
+<script lang="ts">
+import { defineComponent, ref, toRefs, watch } from 'vue';
+
+interface IThemeItem {
+  label: string;
+  value: string;
+  image: string;
+  color?: string;
+  active?: boolean;
+}
+
+export default defineComponent({
+  props: {
+    modelValue: {
+      type: String,
+      default: 'infinity-theme',
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const { modelValue } = toRefs(props);
+
+    const themeData = ref<Array<IThemeItem>>([
+      {
+        label: '无限',
+        value: 'infinity-theme',
+        image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALAAAAAoCAMAAABpXIBCAAAAwFBMVEX8/P79/f/////+/v/+///////7+/z+/v/y9f7w8//u8//////5+fz////2+P7////29/zd5f75+v709/7l6vzr7/3f5Pft8f37/P75+v3n7f3i5vfv8v34+f7g5vz19/3i6Pz3+P3p7v3h6P7y9f/k6fns7/nm6vjy9fzj6v7l6/3q7fje5Pno7fvn7Prl7P/w9P/v8vzY4Prs8v/u8v/z9v/p7v/y9v/m7P8AAADr8P/s8v/a4/7X4P7f5v7U3v56KiX/AAAAOnRSTlPz8/f09fvz8/r9/vnz+vj99f72+v38+vv09P35+/f99/32/f78+vf49/7+9/v6+f7++f3pHPzmpqYAxo5NGAAAB41JREFUWMPUls1u4kAQhA2JA/YqRMJCkGBkgSDkslEsyJ/9/u+11TU90x4m4b7l6baPn0rV7cm+z5+n7j/Rx9f5Ozuf3vM8v8/voT+i8RiHug26cZrcTEajCYQXCj3LJpn0DKW609dd9kjNt9vNdrttZrMGNWumVVVNIxVFXeOURenU92XXe8i+10++TufsE7yUABN5HHQ7VlwDVlK+UR6V1LEEeEVgaiaw0qqmmsbIdQFkVIlTl3J6YAs0YAnKTn1lp/wh4oUiXirwToLFGbHxSlCD0Y8kns8NWEp4UaY9YElMi2spEIuzJTseduoj64LBkEXCQhFZrBoJMLEzQDMYqXwkHg2YrUIqLiJRoFSlPD1zodjusKCsg8G/hdgcjjNBgxV4RGI8qcXiLx3eRJFghmMR2JCJS/UUPTZgJYZ8JBKHPTFZeUgMUjHaRzgFhuYQxo7APsJNjLyHw44YqLRYUFm9yjJhkciFl8gD3jF5aTFq4hymt+QdZhivRKsVDIbDm43iMhJQDGz+euzaO2y8qcP5FYtF0kGsvEIs5mowpNKpW0mEAawWN85jsTjJhMEqMmilSuKyhQxTQ96AfG0Rh0gwv2wJMIjF4o2GWHnF4wtatIFoMJDptHlswAFZF1u8iKlg8YBYPsOWGKW54F5jhBEKBdapi/faT8gMxBK4MLmLIpE/JLzB4GSvEVhKeTl7mfR0S2iGhRgeG3FTuaGrPC55h5sNR7QU5uHoBYcfCIzzm8VElsZ/B5ogWzBciInMZhkWhzl1c/Bu4qmTMocjEViZOzxlvNa8xb/zmsOCx0aj9QfCCAde00oEXkmxx+W/7nKtqckXwHVnFuMkGebcpWtCZcR02K03stJhIU//dwQGLhSmbto+tz4OVXAY+sHhGlNXdOJyT2x12G4T4KUS3mGGNRd+Tciey2gyKgXmliCyWtyu169tHOK9a3EoCE1Q/UD1BB5MHRTN3a2UhViR6bLLhKaYPhN4FPH6qSOus7h5Ph7Wzw4YXT72TqnFJvrrgS3E1/8c0uDuCD2Q6nVTbxTJbpNEMMRk5o345fVwOLRk9XonrrQYOBWIARyF2PubXuL9HkZZiGEpWc3rNMOkxZkRuPl7PB5eOHb1EqrFaTr8vi+A7HFRyp0AQ5YJJTbFvIKMsqFz60INtnVhkSCwc3hO5Pa4PrTTl7ZdQMvlbrdbLHZPT4tlXRdKXBZvzHAAfpPrZfkGYr/WFDnc4X80GI1xcCfgEpYNxyQJ+deb3famCYVhAF6TbjWLHyDRWsWIQkAQDqhdlqVV/P//avfzwnlIiXtJlt2lZ+u3K3cezgEV8YvedtiJ47zZR89RhrlwXDCpk2SFzJBV8g7zEfF33vH49fhWdmEYdl3avo0aZrLNhL0myQ8fHbRQv2RlOKCClvNDX+lsJwZYzcU+iqJnTn06gYwMyIJGs0cJvNjTyvAShpfL5Xq9XgSMgiXqRcz7sWGZYWtYBxiRlmH9MsU1ncI89NIQYx68uFkbmNOTy1l5SOZv7/OkbZMk7ULqFwuh5aazbeLzvW1C6sXyhJBZvP1UDB4hyGuhxx+eil0cF0WRC1iCqRUvxFQy13xYHZDtdnso04/pus6PhCcjRh4dHQ+0QIhF3+6UqU5e9Q9cwTQIYF7uAqRAKgOfn90aYiEj2nCPLsndHkpNSwvMDEZGr/pj8CO0D3zM2RgYVpD2P14gpl9OEQRxHFfsFbGCmTpDtsjG0m3SEt5D27aHtmwRQjN4vLGZ+NGTfcGQSvRgAw2LMYdgNguXwEVVoWMFZ81iTlznHHuH5DDEFV4kmN80BZnYDLaCf/XphBxzvHBgFS+wuEYRLUcHIijiIs8BZrHLojmJXeJWJPYl9zV78FUCeNhZw0ZW73gmtGLf7wst2vAIa/UqF16qGGBwYS5cnfFNh5OD7zczS9NdByHUuEzuGx69deCygq1ijoplE8OPev1cTIdgazkWsA7EZB3VjW4TukUcmFyWLE5BhtnCbgWb+e4jJmLP8Bb/8Z+CgdX9wioegvO+4WYycXW08GKApWVVQ0zpOF589eC/+cBq6JXYXEyVbGKQvXeHhiMBOzxfNrVjsJDnbEbPFJwdtI8JOiUyBuJ2u1nD4sUvee/vxPjnycSfzKwFE9a8WjKTwY2LU15FIj4BvM7q9cK24gQRMKNLskqxqjXw4HDm/FHFGI0X5hJamIrt116swbFREZhHuJggC1RMGZ4eRKZbDxtxaFsEwFcDcwx8d4bNa49pPgye8ipU+lOyDHY73oIBlqefyOHx8rSezDM8VpqZDzvWIv5G68UGNq+J7xeM+KPOXjN8uXZKm5fbRaThaL9vMqRxTVbXdeK22WzmiKteBYNMMTGDX0cF//5VlPvlhmUeoFWnV/u9YknPEkFecXIE2jxvJFlUU8A+n8+bzXY7G4g7Dzbx9Tu+MrAhHr122Ols3EcvptjpLGDF2naxZC+nAhtWFE1WBItDMoBB5tRgk3lj5IuRb90P+lJmdNRp7hRsQ6xerdfEvmHyTnHMKZiz52AwiIxVzCwWdb2tw43cdpS+ZLrS12//72uvxb/52usnEuD0N2m/7EsAAAAASUVORK5CYII=',
+        color: 'rgb(37, 43, 58)',
+        active: true,
+      },
+      {
+        label: '蜜糖',
+        value: 'sweet-theme',
+        image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALAAAAAoCAMAAABpXIBCAAAAwFBMVEXqY6ntaq3tZ60AAAD2l8jtZqvRSpD0icD2bbbtZqvta67rZarvaa7ubrDvcLLpY6jxfbnZU5jnYabWUJXzhb7ygbzdV5zxebbgWp/vcrLwdrXjXaLwa7DRS5DlX6T1kMTxgLrwdLTTTZL3msr0i8D1iMD2k8bziL/0cbT3lsjzfrrwe7f0jcL1h7/2jsP3mcnybbH2i8LOSY7MRov3n8z2isHydbbye7j1dbf0brP2f7z1ebn0gbzHQYbJQofEPoObwpaSAAAACXRSTlOmHOYA6e3qphzmRvmTAAAHmElEQVRYw7WZ7ZrSMBSE8dtsQkPbtVQSquCiFQFbkAKLrvd/V845Scyi/6ROaQu7Pu7beabJpAyePRk8Ff+qG9qdhqTkLSsZJvRuMhl/gd6PoPfQG6fb29tP0B1ed3erFe2rd4/0kfT542enr18/4OX0/NXrZ4MnL8Q/S96ANwAH4iQhXiKezUA88sBMjLcQyJk5EpMisCPGzsCsDwH59WAgrtGfxATLJ4gsBjEACZI1hg6H0WgJ5EjsLV79JmboaHEE/vrhFfJwtSJwQHXRmIEXoXDA2MbjCREzMIgBC+BI7HW3alebFtQfwUq4F8TPB1fCSqm1dtjDm0hMuEgEiIHsNAZvIAYyxyICe2S83+8XIN7gIwX5G8TWQny6FlgAGMoyHCSoFSMz7wTAECEC9wuOeM/ASMUbBgYxIgwxMM6LxfrTvt2v2g0+Uyy+fvjGwq3nkAF8rRjYqaoYXQk1ZOhJROaNEu1uQT9ahBRDGDXW6wXt+33bbtoNOY4Me2Rn8NUOk6lscsbMGhHByZiqqrJMqaG1M/Kagb8EWsgPcHGEg9a3gF2sF3fgbVdt6wYMzi9eTN2LwzcSlA5X4v4T6gYXUBlTQiA3RiLj6m2ChADZA7PDAPb65M9A/gRkhKKFw5sN33qfEWUmZl0HLGm78ckIQ4ZSwBYViFlFgZcBfKUqZRtwj0H9yGK/w+JPawAjxxSKPd15gP4IETSIGfrqUSIOxR4cwDRciMyUxhGz0sIU9JOirEyWiUTUTTfyd1/IBuy9Y/HQxjGGzXA5TCLYrs+wlBSKgEv0DJww8m9iU1mhVKIyU5VFmqY59iItKepN3YzrAxvOtx149y0Bh2kPkfCTHvarHQYhQnFzId8qhkIbz6yl1RUFI9XWKlGCOM/n+Ryic16UKWwXWV2fl/Xy++36lmKxaDcsx83I1wJLh4zjH8B+9hgqoTKhh8qaYrvdTefzVNikaWzFyEw8JW2nux1+v8W/KMvclFYpq87n4/09RXrdMjeZfb3DSESM8V/T3QTDWpJYpcrtnMHmhbYNmGdZQciReYsLYhF5vttNp/l0SsEpRNVU1fl0rs/Avx6YD4hxIGYFYFfewKsR1xJJSLdbI5IJJunJTLpgBGICfthtAShP0mZCIvr5HD/68ePHz90P+F/m8xTA10tCQgSLIzFD02lIzEoIJYxJd2Uy6VAo3i8PtgTSI+Jpamx9xFY31goawDOZ5flu+wBmJwD3Qqx9CQIxI8fWhpPHTixJm9RMwEvz83LZaUM+YsvnRdHYYw2dGgVa6lWZFiSVp/nDw8MPqC9g6SsQJJ3Lj2omFSGnt9SIMqmAG/rEm1HXdELVYtyNu/p0OjUnC15BtDqDw1IKpURVpjsgA7gfeWIvTRFxNnteRNZxc0We/a4Ufmam2WPZkbeQVTzZ8wYJaYVqTkpXZvfjAcC9KRBXLLwRQlFtA20QQQOZKwWbTAIuwnEY1zXjglcQbwRW1sJ5RFuU056A5Q0fY81kGZQf/FVl4TSBAhVHCMSOGaBE+waN/tB1SATz6tCxM86DVKKp7emIYdnWvQCHoQ3HaLIBL1SWhF3hVzaBxejEKMUA9shLJn6/HC2hw4FSXAMaw7v3N8P/3ahTczwCGANxX8CA5RlaymixIw4diO1WViUzIP8OBXHCYljNZ9YZopGtpvGBrhTuno7He2i97wk4PqPwuaiix0COKgy6mkyahEsmExPmiMG9vgfd35/PAMUOWnykttlXhqm0+RYkdLSY8XQo9IUXdUy6I2nwGAE06pbHje+xz7tFyBprkMUadX6DetmbgBwqkNbe4koL6vOWbiWCDsjcEXAJmbaq6Tp4HWijgLoA7x7bYtWu9yjIbW8OQ2RvLG20AsmIVglFRzu0dojLAHJkZlGt16KxTYdOHGmxwrtz6yXwwt/FftMuwNyjw663Pa5AtFyiGycIPsvMBF5Gzmnz3JnWNexeBuwFraGJd3GHUGz25HF/wNyLYyhA63EBfMms2eZoce40xw72qkJMuvp4XK55EtwvkA0K8Z7q/IKA+xyJ2eMooAZiOnE0mkRpF+aUtgAciyaBF1UpMxS35T2isUcwWvjMmejVYcnEUSICR4eptAH5kcd5ZI5LkPk0T+dpmQldH++/34N5s17D4j4d9s9fo2IoAjC1OMx4s0RVZUS+dJmR/RoE4HmZl6VsNJZLazj9HxyOyEM+KAjMLhAwmEom5jplykfAaST2zGGtt91hR1Boja2Ppz4d9im+xGXR0p/zMERFns3cI80JXH5MHIFTugGBPAdoMBsrPfqU9uqwew504bFTgh3ucqn3lXgEjWfSlBfAOBncbidcnM5MiR87o+MidfC0V4cvLY7rOyL1bT4Y7J9yo64bHjAgY7Spm0OHbdx1XI6F0UWee2To5aDPuuY7BY7R4Mtn3Kjw4Rk38+Jrjzd4YDWbKNs0hxM6cd3VLG7GVggclFD0SGBLxAN8KdMnMTYIc/SfvN5eJp5Ei1lUiKmyka3MypXYjd60cBaVFcdMl8V0+/IJf+3Vo8EMrLVjjivoaHFA/kJfMAVkmD0id4O5J7gLWF42gxkdqjJKqaeDJ89+AcjNEnPHeaw4AAAAAElFTkSuQmCC',
+      },
+      {
+        label: '紫罗兰',
+        value: 'provence-theme',
+        image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALAAAAAoCAMAAABpXIBCAAAA0lBMVEWAbfR5Z+56aO4AAADMrvl8ae9bTuq3m/e0mvZYS+l7ae5+bO6Cbu+OefCKdvCFce9fUeqWgPFtXOxzYu1jVepwX+xmV+uTfvFbTumYgvKRe/FVSemIdO+chfJ1ZO1qWut5Z+2fh/PRsvqhifPOsPl4Zu2ljPOnjvROQuhSRujUtfpoWeupkPSahPKsk/Tbu/uvlfXXt/pZS+nLrfmji/NLQOdHPeexl/VEOua0mvZAN+bApPcuJ+PIqvjEp/i3nPYiHeK6n/Y8M+W9ofc1LeQUEeC/7zqRAAAACnRSTlMc5qYA6e3mpqamYzoExAAACVBJREFUWMOs1tuSmkAYBGBzqqQ4SxAVNbiiCCYQdlFE8LzJ+79SmskPrBNuxPSFtas3X3X1DHQ+dN6/E+6JyCKJEqIWGY/HylhBZIpl9Vm6RYZFgmCCPBVxHGe9dl13uVz++BGGYRRF2+1udzqdLsjra54fj8fD4RBzmSMfv4Db+STc7wWYhbzgspAXYIu45K3B4Los5A3Ji4BbeZkQoU/6F+RO5z0QbcUERv711mBoWaClfhkXKb0MzNrNWbvEm83mVeiL2ecO9nBnbrwIz7W4PdzOAam9Ee8FF17I3qTmIh87QmswvwjyAsz1GxCX9gAuwDcD3p3K+YIL2qrObD5j1lLcaeFtBlcF1/3+FVfrJS+JCQwvuAAzL+PC+1wEnwDPCnIFXt0NFuuG1UYwDYJhqwWTlwouG44IvI0IzPpl3J9IYS7EDEtegB8/c8o/DVO/3P3gcN5qwrIeBMsCDC9M4JYpxVXBz49vuPHMNRSMuE0L3u6iXqZpVvgXvAKYF9N9UXgBfnzDzWeOv4BpElRwWIIhDl6um40mhlQwgSnwlsFvh+PjYKT5zDWA6YkB8JuKnV7yYm480wF4VoKJHM/ZwcvRblHwvPvtfvBdh44Dk/j2Gu4a6Df1v10K8KpuGOiDqpyO88tFiWfI8/Nlav63e5ifBMB06KqnBuuYGwXAy6mfeMnAGL7iofF2Evmua/qCYi1kY1tcbdFRNpV2k0CaGkZKMIkREldg5KZi90nyk8wb+T01VPpxBcYfa1vbjPzU08ypE6/i/vR69duD+Yb5TdCKAW6YMULirfpd0/w02Qy+T2VD2M0IvIrdZT7WPHvgDzLbGzhdd2Gn+3NLsESb4MH1TczCwExM3oar2M686dQY6bohuQs1ZJsAOO/3JcHWX4zRQNtke/2HruqS5HltN8zAzY8OEvNva/zBAxjkKFR9z1ssdFH4pj71rWHOjt38dfckij3N0OwX/J4k6lA77/d+9uAkCNxUMcK/D9MLprtmYtdhYEcwk1S3NVtWLMeVu1Eex3k8n6hBV572DNPWkzS9ZiMz1XzT+33+Lw0TWebeiDkxK3kINGt5YvaKkiNXS7JM07XBdCz3ZWkSLh1rEkaWJK27imQOfC/dXLOett8Lo2t6/g1w23ut6SrmDl59W5BZtiVp4oDsiImhQBxN9PTqfTNt+6sSKILSX1qBpEzksSiqsjP+OjbTNNuPNudf5/P5V9YKLDaC3zzu/rRm7j1Lw2AU95KY2O7y0BvdCm2Jqa6pGrM4gmjUKH7/r+TpBI3xL9GzG1t4x6+n52nZC4ivGb5S3wpw39rs9ADgQyusVe2zl2+2cjqTlpJr2XK+HTrcs9m1DZNeHvaya6bT6XL6jAB//uxougD4Hzxeaf8wGJhtPR0ratvi9AY8Egqfty9evNoJoXw6vH7z1h+pcyfWB6l93G067oXcjT2TOghPltz58uEC2vOXz9/OyxcA/5NuXt9Mh9CG/mZ/1zLdbbu+227A+2wXx76Ifr/vZF4ydfhW8W5XGHdTZBREkk3HGylEP9a99oFcdsuXD58/LB+yoMsfGb4fGyvErhtgIex5sCSjmklreD5GzUue+XbUx/OX88zh+ygduWmxdnFGCyxMCs3bLulQjCLKeOflw4fjcVany+XbvcD8d7GYGCYTYUQE6HViQVwastkWkZfJqsTH0UdjyXaHkc6n7GyJw7OO6eymybolO2dV0FKb4HeNF6VYvHmewItMQKr/8O3DXcARW0oxJp+8ry+ECEVKfATM4eBWImhRhDeZnHWiTCoUEaKZrXV25ty78+Qg8lw4dzpOE9YpA1gguqQ0i8KUoMA7uy+oN0C7L0J8u2dqZhGkkPde/pCGK9hEqD0aggo0K4JZdrY5WzvNopAJwYVggrXF5tMyYTY4ZtKsaTqf83QEcHWYTCHrSO448xFxts7B4XNWyukU0VXuwX8IL2NSsqpUW4IGeeGlTpynoIwuRJKLYqQSTdcH0g7xxeB6OpoixsP+2SikyFNeE2FC0TN1h5cvXrx+dnh+2HrCsNaMqNm379+/wAPK/cAxrnvvgS2DkIl5Lb3ABpcFXinEovZwzUsQylYDaZ6JLI64oiEpyKh6GcSTJSRCeqXbw7O3h7eH/QaTY6uN5nXa/vTx62b/+uVdkWBxPSSkQchqszbGCM84A1wAcQ1zlMEA1pAKAkJsKj3aU4IOhiw5hygsx+NxWfLsiBAb7RO6pm/rdNP1TTu0GOP7Xd8PA8qYa9939zgcr+YmLSU6vjpcjCmwkyMGqD2lhE7wPkU0CQuqUMFURaoWUc4ZqFPGNi3rsmYBKrrWQ9+Om+EwdD1nfddDXfQwJyWtjqcFwPchJ4/eq+AcyACGajdLCMgFtVd73q4ivJiRCGjl/QEN3muhkZtgsREyRpk6uDvskYe2ZxEjeULtGXSY1mSn5XQncPJe+gTBRjCnYFYFgJYaWmwrs1s1z3NltT81g89W3ozcalGStEbymAQVX6f0V/u39Zsd/G24j7EmCp8ncLvzfZFIVf42soFcw2KFpa6lYLcajotk4eUvVdPrQeEtUhdlCdWGpqACY5CoDcw57Tjsn794O7RD9RjdJWVkSWvvA50u/wL8g1evqharioGg1lWBuxqOE6MsIDMErysu0WwVXGOsQW8HIku67xmOwew2m/U5cHiLp4+x730dIFkTvagNJJfvLLorLoCvyOLGC8KqEGCxUQXna0wKqTkDHNDQTAYi1CbjsWm7bhwOG66lZ127fTVuXiDB7TAOW8YRigY+J+55mAnPdA/vAo5rHH4BC2EgBa3AQCdV6gUCrwk6pch80cKtc5qzQJ/Bna3B3/Omqd+iN/3OY1wY3r58/vwwbAf8NxGuN41VhaiYFNBn9smDR/dY/DMRuvKKqvKTmLBigYNkCTtFIGaeN5FJXJqOGH1zpZ2sm9xskNx6C6OFFzph8N2/Grft/tVhM+4a3XSatDbC5fNxcdNT/Chzn8OQr7oaLAJobwabai6tKnVMoDrpafwN9yFQnSyWCTPbUveOcKmUdeLwXrHd2PCu6zav2v2mb8ZGCa/7psP9J4tx+8Hf/+wF4BvyDRi4IhRz5b1yW4JwYrEr6IYgY+/76KXLdXqbwHs+n84L8pGxkTZz4CLwxqd9O46v+nbXSuRIqsj6yDt81sNHDx5/B9WliVyj/kfAAAAAAElFTkSuQmCC',
+      },
+      {
+        label: '深邃夜空',
+        value: 'deep-theme',
+        image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALAAAAAoCAMAAABpXIBCAAAAq1BMVEU2PlI3P1M3QFs0O1IAAAAQGSwDBQocJDgSFiA1PVEyOk4wOEwuNkobIzceJjohKT0YIDQoMEQlLUAWHjIqMkYmLkISGi4sNEgOFio3P1MHCQ0jKz8hJzYDBQoZHioICxEdIi4HDyMWGyYfJTMLDRQdIzEQExwCAwYbIC0SFh8LEyclKzsOFCIAAQQUGCMjKTkKEB4NERg5QVUECx4CCBgBBhIWHCk8RFgHDBqitgHvAAAACXRSTlPpphwcAOnppqaXFY5vAAAH90lEQVRYw6yWyY7bMBBEnQ2BRFFcRG0QcsjVR+fg//+zvGozlqPkEjmlZrfGFjBvCkVqLp8/frg0/6yWi662rrpz7W9qfrXH9xRauV1v7Xpb7/f72nBz44tubl3nXJq7ccxjCn3fh973vQ+s6OPwEHP68vXT58tHcE8CP+n49Ss/7dT1b9G6NUCKVcR6EN7bHVQ+gL4VbQPwXLjGcesDoLEP3ojjME3TEPvIWJYpfPl0+dCc1ouht/u62wyourSai9AhnpCxBrzezXoEsWuc68o8z2nMCV4EbQnBez9Mw+D95MFdrtfr96+XyxvAXBWRMo+Zv4BXypy9i1dOMwyTLjF5sGvn0iEBl5JzDiaf3BgjsBGX4ySHAZ6WL+d5W2tHmbN1WlVOk7hXdZGqiAIOz0JOCd6U8xa2jRRHTM7RDyQ3RhKyTNL379c3gKu91VZL8OGzR4Krm1qYvu/Adu3mzhLcEYZUSpvIcOjxGGDikNl8ABOJSJ+weTkPvGf1bxJ7PUlophrX+pljKAWwKg4pjah0zBAwePSSTgmKGSOwiBCfBT7Y6w4nmmDrMNDGHujgrM+72c2pEAMRlwIyR0RSJmzXGW8IkQwDHAcBX/vl+v0cMBRHS90xyVq61vq9U7Np1SkHSYiFQw2vk2JBLgAmCVvpPXOYuCRzGN7r6UgceGu9oEMFsmvUHMug4XSdPaMclFGMSccDtDCnPLPrMhG28iSY2qIGxzGJWJb/BmyEr/z2iKEiMYJqwGBLYGLoKOSicoUgKxMAk2OvjYdibFma9rqbAH6b2FXgHZ62Wy2LwWxYrZlMzUXLnEVmNCPDz6YLWfuN6HqBbiEibuE9D6x0Hvx9BrV2TSOEV7Pai2DtgJVAFbJ2HNaOmXONg21j28EreQ7kwVB7e0sPZ4EPDiNDJgBPUpXddA81rQ0Mn2eIEUEAPCe6XhkUuAB7rtBHRvRUtFPCMjGddLj9E/gVG7HdgG8eziK1OlkQs4TMzlN2Kd4ZYwpB/nqYBSuXKS9QaEGf/keGncnmi79KLE8pA0/SWReiiboUHWuIKFDZTA54SwmYHMvdbZggDj02n3f4L8DuqT0kglUB+uA14MKiwzvOqRQBb2MuW8ZhOyEqM7RRzYBHe334eHnHXxtGZ20XiGr4C+aYOlNlLkIFdBYpFtf9tiUWvBZhVajx9QImCxP29hGH3/S3Ih8EKLzCnnPAOdlcsyBefJXP8GqNtt8CuALO5i6CVnOQBK3/4Jcf7zi86xmGZwfVejHbctoTbMQGba/mUQYrwciIpeiFygiDbTmTxvdvP0sz0942gTAIt2pV9RDGrFOCOM1hDJhwCIz4/7+sM6/XxXLSD4XxLiRSpDyZzM4uNoC3lwQzoUkJycmX8MLgnalMiykmqwbmYuPpjLgMBBpNaAlsCK5ecmA/3JFhMIA31vD7NGhg8FkCgQkbcbcEWGBfJcEcDIR2lz+rPEGWTLAWIFyAathVNQzXt+0Ok/gJW9euZfrUToFYST5ZB3d/WcGUugHzb2OOhRf6rfYEFlioGoLrdRjf1gD/fAT+yF0N/GqmLX+/7/GA4HlkJtULD2p3YIXhedyAhRgeCy9jjBIjcDWM1zgOxnEYxyC4rnR40ZOzciUw6qFtTc/67ae735ZnHE+m4hkBVMQl8c1gk1xOXaNswUkZuoGZXMOJhpgahiEA71bgX8/EekKeD8uU9arSI4iR4bAwQEypWyxIyzM6gcu6znsAkpeTBjvxXDlgrTCZhxG8wactNUzg93EQvahWedy7LDM9pWC0lGmE+30hq97keVIJlo0ewNVx8jx3cNOZ4CNR3EUzcCsCB8jEFWNlrf0TGJKL9QJAD1hoq/R4Oh1P7DajCENAg4iUhs39IJGnIAfANXrAqStnz2VWdfEcRVE80N9xgOjv+S1Yt9O9x9XO6hvbS7VYUaafQgCGDESE4UwMhVU2TUlyODSN1Kttlw4SW+d134O967Jo7mbwxi4TPA9XxHcM3qBtwEuGF1xIDjZsgdb3U39HYCrk/7owDqGB/Xea7MlOGjAfDMh2YHPd110HevgLVdHsuhlwZ0YhCM7n83pgDA38uFFovfAQJpstithMGQkSF4VR4HRQ7HYFGG+bg2wK/MaucUJnFGCwTV4st8h13TmaRxehAO8W4B9LJB4d1s+WPCGolrsGJ/3FgMKiCA0jCeUMJicGWWEMsV3Xkgx8BWIkIurizEWI5xg2n8/BAryphN8Bv1o09nJpL63JPKSc4NXAIKb2+3AKD3CbrtplXuZ57SDAVY5MIMRZ1sVR5GYzTKbNwF0N/JdTS+PeM2ypi+JoPf+uFNIZDgu8EhIfkqRJpkPCpWc3ZckazjGzrAd6hkhEVObeFGx2eHmyeKxfdBnEDUE7TJGXFhdH2ktgjClpmsmYSrCyKvImL8FLVq67jCLwwrs9EmBcqneJw4WH2wsy0baE5YT0qqNC8iYwNkHBNQBGcOkw/cVm51R13XfEFX3g8FpiopJXxLtFXhCTlqPVGRZebbHgclLT1EAlAowJ9Xnf9xJhiLDZB8DfPn1eA6xj+4CMbkAUyEtkAfapxWFIO6yBxV9MKhf1VCYSVs4lEwL8/b8/lPkpwBQo9ZsM5JXTFxPxF/gxw0+ZQCQocXgBxu6sgbXFDw6fb8Dfvqz42EsDS+cCllM/PzDCEHkfgXWvFYvDT8CNENdo4HoBZg0vwNT52/cvX/8AzhzJ9DpT3OYAAAAASUVORK5CYII=',
+      },
+      {
+        label: '追光',
+        value: 'galaxy-theme',
+        image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALAAAAAoCAMAAABpXIBCAAAA2FBMVEUfICIgICMkJCQAAAAfICIgISMREhQYGRsVFhgGBwkODxEmJykKCw0bHB4iIyU0NTcDBAU3ODouLzEsLC4pKiwkJScwMTM5Ojw/QEI8PT87Oz0zMzUaGx1TVFZaW11QUVJHSElub3BJSkxBQkNERUdnaGmen6FjZGZXWFp5eXteXmCAgYJCQ0VycnRqa21gYWNNTlCwsbJMTE6ZmpyUlZeNjY98fX50dXeqq6yGh4m2trekpKWDhIa8vb7BwcOJiouQkZLV1damp6nNzs7Gx8i5ubutrrDJysxyHvRGAAAABHRSTlPpphwAI2YUpwAABa9JREFUWMPF2dt2mlAQBmDTSg41kYKKoHKW80lRQKqp1jTJ+79RZzbUXUNyV8yseJGbrG/9658Jaufrl6tOt8VhYPr90ajXGw4HvMCynBSmcqJ7QZBHlpLOJW4q8MNef8R0uw/dh9N0m9O5+vK186VNLnoRPOqP0Dvgpyw3Ng1VsYo8CLzYVzVxzBIvg9bZ7ObmZkbRDTdwr7ptDc23X+dLvOI8dSHgPPAix03DCSsMwAvpgvUWBsT4M3uffNVpvQ8M7YPAchPJNGTfirw8LyBgKATJF7movYYXosnM3om4bS/Nd8jzAgQsifMFBFzkuac7rmFyEPAIvbfXp6HoWVPcJpjBQW/dXyyEFNYBe7Bx6nzM8oMeU3m/1YPmk3h2Lm4V3OwvejVVcfTC8wo9kQ0RvMN+d3YD3Pt6kEyGkunfbA3c7C/GO4ZCpBCwXtqr1TorA5wd/OCU++wQXN/d3Z3QVcqXAdN8R7V3yo7HEzE0VNeJo71t26tDVhJmlh3W67W93SyX9u2ngWl/e9BfyBcPhBhqsHGWXpSrLNvvdkHueR6mXGbrFWb+AZiK2wLTfNEL9wH6AF5TS2VocATgQLcUOdVMaTzhBKE6eJyznCG4IW4fzODQPtTecG6oGHAUlXaQJK5qzE1R5AcciwdkIo7014fvKL48mHDPFg684pwEHFdgJcjKcr8/2Gl4hEYfl4/bXvH0KWCaL/bh5DXBWwesBytPzg/7/T5bb9X5y3Z7fHl+3fSKX90G+I2Ygtvw0oM2EWHhDBUCtnRdj/N1oXrrlW1vjxslfX78+fvp168XADMAbojbBje9VcDGQlZ8Kwav5a11w1uDGMGL5Q8UA1i/NLjpxQNBAjargBMrjmPLKbJYK7IDydhNPx988taFOAWcOBZ6fX1vhRGCVwA2avCyAW6IWwDTB4jeuRcDRrBlOYkSl44YZRkphaudwDGAz8TtgxmcMy+5ECRg1UUwemVrl0gkYYhYDjeV+KVnfQq43yiwhA0mK5c4ML6iJrky0cs9abGL4GcA/+hZT90PwCim4NYWDguBG1fd4Aqc+Iqc+p7LqX7i40x4iD2OCi/uK78p+FzcCpge4NFp4aqAxRBXzlV8P0HvQlM8mZM4VoCn4cGIGfZIg/iu+ghgIr4ImHmzcNVbjH/BIPYVfIRwPZl1vKLw8l2Wcmu8FscfK0b5+RlgetFqsFjdCADjuBCwKUfy1MmDXQktlqXt5gVLvOknr8x74DNxpwVvfSEE9u/KYYUXsuy6iuvKqhGKqi7zCYBx7VxxW52JTTd5IuCGuBUwPRB049CL4BDBKoDRm87FCYL9PCcJKwhG8bHvQMIwlwHThUMvgtk3YFWGUReGKXELXRWUwsOMD65pb8lhOw7iC4KZt2DhBJZEABsLFKvqIp2bE86wanAJYAPBmDAfv/bfgJviTgsXogp4SsCkwwhOUQz5aqHIsYZFE/YZ1a7BOoCb4vbAdOMwYKwwgv+KkQxeaDA3nTsL3o0IOFt8Y9Yk4i0f/2yAmwm3FDCCa7FUiTXNgFcIDWanoZ/ysq6TUpjXo4N9hMOGYOaCYPSeg2nEKEayNjdFAAumbwxSP8FnoUieheVuDw8V5XnCDfFlwCRiFCN5jt4xO+VFxRjIcYT/6aLp7TCqKiHojwCm4vbA1EsqTMFUDGQY9OIjhARgNYZKeIsZfgo4XoHY5j8FPDyBqXgsARlHkiZjFsATWRuk+IZfgU+EwXTvIFiIHpkPwCiuwZ12wDRiFGORYdDLQSMGYwAbCBaBg+AJgtmCgt+JuPZe/TfwqAK/iZitxTCVtwYPEVxMScDf7h/s5XLFRs/M3R0Rfwi+gm85/if4POIpDbkaDr0CP+RUbWT4jhX3SMDAKjdL6PB7YBgKBi5+7fX/wRgx7TEd+A2f2tk07GkAtrrgRfB9DmAh+hCM4uprrz9u9n3vcmMIqAAAAABJRU5ErkJggg==',
+      },
+    ]);
+
+    const initActiveTheme = (theme: string) => {
+      themeData.value.forEach((item: IThemeItem) => {
+        item.active = false;
+
+        if (item.value === theme) {
+          item.active = true;
+        }
+      });
+    };
+
+    initActiveTheme(modelValue.value);
+
+    watch(modelValue, (newVal) => {
+      initActiveTheme(newVal);
+    });
+
+    const changeTheme = (theme: string) => {
+      emit('update:modelValue', theme);
+    };
+
+    return {
+      themeData,
+      changeTheme,
+    };
+  },
+});
+</script>
+
+<template>
+  <d-dropdown :position="['bottom-end', 'top-end']" align="end">
+    <svg class="icon-theme" viewBox="0 0 1024 1024" width="20" height="20">
+      <path fill="var(--devui-text)"
+            d="M512 96C229.696 96 0 325.696 0 608c0 90.368 30.304 174.496 85.344 236.896 55.264 62.624 129.152 97.12 208.128 97.12 81.568 0 161.536-36.832 231.264-106.592l2.272-2.496c65.792-81.472 132.896-121.056 205.088-121.056 46.72 0 89.216 15.872 126.688 29.92 30.336 11.328 56.576 21.12 81.216 21.12C1024 762.912 1024 654.336 1024 608c0-282.304-229.696-512-512-512z m428 602.912c-13.088 0-35.296-8.288-58.784-17.088-40.48-15.136-90.848-33.952-149.12-33.952-92.352 0-175.328 46.944-253.76 143.456-57.184 56.704-121.056 86.688-184.832 86.688-60.352 0-117.216-26.784-160.128-75.456C88.64 751.872 64 682.784 64 608 64 360.96 264.96 160 512 160s448 200.96 448 448c0 27.328-1.952 90.912-20 90.912z m-203.296-182.848a64 64 0 1 0 128 0 64 64 0 1 0-128 0z m-343.68-202.688a64 64 0 1 0 128 0 64 64 0 1 0-128 0z m215.68 26.688a64 64 0 1 0 128 0 64 64 0 1 0-128 0z m-381.312 112a64 64 0 1 0 128 0 64 64 0 1 0-128 0zM182.4 698.752a96 96 0 1 0 192 0 96 96 0 1 0-192 0z"
+      ></path>
+    </svg>
+    <template #menu>
+      <div class="theme-picker__dropdown-menu">
+        <div
+          v-for="themeItem of themeData"
+          :key="themeItem.value"
+          class="extend-theme-image"
+          :style="{
+            backgroundImage: `url(${themeItem.image})`
+          }"
+          @click="changeTheme(themeItem.value)"
+        >
+          <span class="extend-theme-title" :style="{color: themeItem.color}">{{ themeItem.label }}</span><i
+          v-if="themeItem.active" class="icon-right active-theme"
+        ></i>
+        </div>
+      </div>
+    </template>
+  </d-dropdown>
+</template>
+
+<style scoped lang="scss">
+@import '@devui/styles-var/devui-var';
+
+.theme-picker__dropdown-menu {
+  width: 176px;
+  margin: 12px 16px;
+}
+
+.extend-theme-image {
+  background-repeat: no-repeat;
+  height: 40px;
+  margin-bottom: 8px;
+  border-radius: $devui-border-radius;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  .extend-theme-title {
+    margin: 0 8px;
+    color: $devui-light-text;
+  }
+
+  .active-theme {
+    color: $devui-light-text;
+    margin-right: 8px;
+    background-color: $devui-brand;
+    border-radius: 50%;
+    opacity: .6;
+    padding: 4px;
+  }
+}
+
+.icon-theme {
+  margin-left: 10px;
+}
+
+.icon-theme:hover {
+  path {
+    fill: $devui-brand;
+  }
+}
+</style>

--- a/packages/devui-vue/docs/.vitepress/theme/index.ts
+++ b/packages/devui-vue/docs/.vitepress/theme/index.ts
@@ -1,16 +1,28 @@
-import DevUI from '../../../devui/vue-devui'
-import Locale from '../../../devui/locale'
+import DevUI from '../../../devui/vue-devui';
+import Locale from '../../../devui/locale';
+import '@devui-design/icons/icomoon/devui-icon.css';
+
+import { h } from 'vue';
 import Theme from 'vitepress/theme';
 import './styles/index.scss';
-import 'vitepress-theme-demoblock/theme/styles/index.css'
-import { registerComponents } from './register-components.js'
-import { insertBaiduScript } from './insert-baidu-script'
+
+import 'vitepress-theme-demoblock/theme/styles/index.css';
+import { registerComponents } from './register-components.js';
+import { insertBaiduScript } from './insert-baidu-script';
+
+import ThemePicker from './components/ThemePicker.vue';
+
 
 export default {
   ...Theme,
+  Layout() {
+    return h(Theme.Layout, null, {
+      'nav-bar-content-after': () => h(ThemePicker),
+    });
+  },
   enhanceApp({ app }) {
-    app.use(Locale).use(DevUI)
-    registerComponents(app)
-    insertBaiduScript()
-  }
-}
+    app.use(Locale).use(DevUI);
+    registerComponents(app);
+    insertBaiduScript();
+  },
+};

--- a/packages/devui-vue/docs/.vitepress/theme/index.ts
+++ b/packages/devui-vue/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DevUI from '../../../devui/vue-devui'
 import Locale from '../../../devui/locale'
-import Theme from '../devui-theme'
+import Theme from 'vitepress/theme';
+import './styles/index.scss';
 import 'vitepress-theme-demoblock/theme/styles/index.css'
 import { registerComponents } from './register-components.js'
 import { insertBaiduScript } from './insert-baidu-script'

--- a/packages/devui-vue/docs/.vitepress/theme/styles/demo-block.scss
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/demo-block.scss
@@ -31,7 +31,7 @@
 }
 
 .demo-block-control {
-  background-color: var(--vp-c-brand-dimm) !important;
+  background-color: #ffffff !important;
   border-top: solid 1px var(--vp-c-divider-light) !important;
   color: var(--vp-c-text-2) !important;
 

--- a/packages/devui-vue/docs/.vitepress/theme/styles/demo-block.scss
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/demo-block.scss
@@ -1,0 +1,81 @@
+.demo-block {
+  border: solid 1px var(--vp-c-divider-light) !important;
+
+  &.hover {
+    box-shadow: none !important;
+  }
+
+  .source {
+    overflow: unset !important;
+
+    .demo-spacing {
+      & > * {
+        margin: 0 8px 8px 0;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+
+      &:last-child {
+        & > * {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
+
+.demo-block-control.is-fixed {
+  border-right: solid 1px var(--vp-c-divider-light) !important;
+}
+
+.demo-block-control {
+  background-color: var(--vp-c-brand-dimm) !important;
+  border-top: solid 1px var(--vp-c-divider-light) !important;
+  color: var(--vp-c-text-2) !important;
+
+  &:hover {
+    color: var(--vp-c-text-1) !important;
+  }
+
+  .control-button {
+    color: var(--vp-c-text-1) !important;
+  }
+}
+
+.meta {
+  border-top: solid 1px var(--vp-c-divider-light) !important;
+  background-color: var(--vp-c-brand-dimm) !important;
+
+  .description {
+    border: solid 1px var(--vp-c-divider-light) !important;
+    color: var(--vp-c-text-1) !important;
+    background-color: var(--vp-c-bg) !important;
+  }
+}
+
+[class^='version-tag'] {
+  display: inline-block;
+  padding: 0 4px;
+  line-height: 20px;
+  color: #ffffff;
+  border-radius: 4px;
+}
+
+.version-tag-1 {
+  background-color: #3dcca6;
+}
+
+.version-tag-2 {
+  background-color: #f66f6a;
+}
+
+// doc code 文档块不显示 css js
+.vp-doc [class~='language-css']::before {
+  display: none;
+}
+
+.vp-doc [class~='language-javascript']::before {
+  display: none;
+}

--- a/packages/devui-vue/docs/.vitepress/theme/styles/index.scss
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/index.scss
@@ -1,0 +1,2 @@
+@use 'vars.css';
+@use 'demo-block';

--- a/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
@@ -121,3 +121,7 @@
   width: 100%;
   display: inline-table;
 }
+
+.VPHome {
+  padding-bottom: 10px !important;
+}

--- a/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
@@ -119,7 +119,7 @@
 
 .vp-doc table {
   width: 100%;
-  display: inline-table;
+  display: -webkit-box;
 }
 
 .VPHome {

--- a/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
+++ b/packages/devui-vue/docs/.vitepress/theme/styles/vars.css
@@ -1,0 +1,123 @@
+/**
+ * Colors
+ * -------------------------------------------------------------------------- */
+
+:root {
+  --vp-c-brand: #646cff;
+  --vp-c-brand-light: #747bff;
+  --vp-c-brand-lighter: #9499ff;
+  --vp-c-brand-lightest: #bcc0ff;
+  --vp-c-brand-dark: #535bf2;
+  --vp-c-brand-darker: #454ce1;
+  --vp-c-brand-dimm: rgba(100, 108, 255, 0.08);
+}
+
+/**
+ * Component: Button
+ * -------------------------------------------------------------------------- */
+
+:root {
+  --vp-button-brand-border: var(--vp-c-brand-light);
+  --vp-button-brand-text: var(--vp-c-text-dark-1);
+  --vp-button-brand-bg: var(--vp-c-brand);
+  --vp-button-brand-hover-border: var(--vp-c-brand-light);
+  --vp-button-brand-hover-text: var(--vp-c-text-dark-1);
+  --vp-button-brand-hover-bg: var(--vp-c-brand-light);
+  --vp-button-brand-active-border: var(--vp-c-brand-light);
+  --vp-button-brand-active-text: var(--vp-c-text-dark-1);
+  --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+}
+
+/**
+ * Component: Home
+ * -------------------------------------------------------------------------- */
+
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background:
+    -webkit-linear-gradient(
+      120deg,
+      #bd34fe 30%,
+      #41d1ff
+    );
+  --vp-home-hero-image-background-image:
+    linear-gradient(
+      -45deg,
+      #f56a92 50%,
+      #61c4ec 50%
+    );
+  --vp-home-hero-image-filter: blur(40px);
+}
+
+@media (min-width: 640px) {
+  :root {
+    --vp-home-hero-image-filter: blur(56px);
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --vp-home-hero-image-filter: blur(72px);
+  }
+}
+
+/**
+ * Component: Custom Block
+ * -------------------------------------------------------------------------- */
+
+:root {
+  --vp-custom-block-tip-border: var(--vp-c-brand);
+  --vp-custom-block-tip-text: var(--vp-c-brand-darker);
+  --vp-custom-block-tip-bg: var(--vp-c-brand-dimm);
+}
+
+.dark {
+  --vp-custom-block-tip-border: var(--vp-c-brand);
+  --vp-custom-block-tip-text: var(--vp-c-brand-lightest);
+  --vp-custom-block-tip-bg: var(--vp-c-brand-dimm);
+}
+
+/**
+ * Component: Algolia
+ * -------------------------------------------------------------------------- */
+
+.DocSearch {
+  --docsearch-primary-color: var(--vp-c-brand) !important;
+}
+
+/**
+ * VitePress: Custom fix
+ * -------------------------------------------------------------------------- */
+
+/*
+  Use lighter colors for links in dark mode for a11y.
+  Also specify some classes twice to have higher specificity
+  over scoped class data attribute.
+*/
+
+.dark .vp-doc a,
+.dark .vp-doc a > code,
+.dark .VPNavBarMenuLink.VPNavBarMenuLink:hover,
+.dark .VPNavBarMenuLink.VPNavBarMenuLink.active,
+.dark .link.link:hover,
+.dark .link.link.active,
+.dark .edit-link-button.edit-link-button,
+.dark .pager-link .title {
+  color: var(--vp-c-brand-lighter);
+}
+
+.dark .vp-doc a:hover,
+.dark .vp-doc a > code:hover {
+  color: var(--vp-c-brand-lightest);
+  opacity: 1;
+}
+
+/* Transition by color instead of opacity */
+.dark .vp-doc .custom-block a {
+  transition: color 0.25s;
+}
+
+.vp-doc table {
+  width: 100%;
+  display: inline-table;
+}

--- a/packages/devui-vue/docs/components/accordion/index.md
+++ b/packages/devui-vue/docs/components/accordion/index.md
@@ -272,13 +272,12 @@ export default defineComponent({
   },
 });
 </script>
-<style scoped>
-.menu {
-  width: 200px;
-}
-
+<style lang="scss" scoped>
 .menu-wrapper {
   float: left;
+  .menu {
+    width: 200px;
+  }
 }
 
 .menu-wrapper + .menu-wrapper {

--- a/packages/devui-vue/docs/components/overview/index.md
+++ b/packages/devui-vue/docs/components/overview/index.md
@@ -32,7 +32,7 @@ Vue DevUI 组件库包含 77 个灵活、易用、功能强大的组件。
 </div>
 
 <script setup>
-  import { groupBy, startCase } from 'lodash';
+  import { groupBy, startCase } from 'lodash-es';
   import { componentFeatureData, STATUS_MAP, CATEGORY_MAP } from './feature-data';
   import { CONTRIBUTORS_MAP } from '../../.vitepress/devui-theme/components/PageContributorConfig';
 

--- a/packages/devui-vue/docs/components/read-tip/index.md
+++ b/packages/devui-vue/docs/components/read-tip/index.md
@@ -95,7 +95,6 @@ const readTipOptions = {
       position: 'left',
       title: 'This Is the Second Title',
       content: 'Class aptent taciti sociosqu ad litora torquent per conubia nostra',
-      overlayClassName: 'child-class',
       overlayClassName: 'red',
     },
     {
@@ -204,7 +203,7 @@ const readTipOptions = {
 };
 </script>
 
-<style>
+<style lang="scss">
 .read-tip-demo-icon {
   cursor: pointer;
   font-size: 16px;

--- a/packages/devui-vue/docs/contributing/index.md
+++ b/packages/devui-vue/docs/contributing/index.md
@@ -13,7 +13,7 @@ Vue DevUI 使用 `pnpm` 构建 `monorepo` 仓库，你应该使用 [pnpm 6.x](ht
 2. Clone 个人空间项目到本地：`git clone git@github.com:username/vue-devui.git`
 3. 在 Vue DevUI 的根目录下运行`pnpm i`, 安装 node 依赖
 4. 运行 `pnpm dev`，启动组件库网站
-5. 使用浏览器访问：[http://localhost:3000/](http://localhost:3000/)
+5. 使用浏览器访问：`http://localhost:3000/`
 
 ```bash
 # username 为用户名，执行前请替换
@@ -30,7 +30,7 @@ Vue DevUI 是一个多人合作的开源项目，为了避免多人同时开发�
 
 > 提交之前需要给Commit添加GPG签名，参考：https://insights.thoughtworks.cn/how-to-sign-git-commit/
 
-1. 请确保你已经完成快速上手中的步骤，并且正常访问 [http://localhost:3000/](http://localhost:3000/)
+1. 请确保你已经完成快速上手中的步骤，并且正常访问 `http://localhost:3000/`
 2. 创建新分支 `git checkout -b username/feature1`，分支名字建议为`username/feat-xxx`/`username/fix-xxx`
 3. 本地编码，需遵循 [开发规范](/contributing/development-specification/)
 4. 遵循 [Angular Commit Message Format](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) 进行提交（**不符合规范的提交将不会被合并**）

--- a/packages/devui-vue/docs/en-US/components/read-tip/index.md
+++ b/packages/devui-vue/docs/en-US/components/read-tip/index.md
@@ -95,7 +95,6 @@ const readTipOptions =  {
         position: 'left',
         title: 'This Is the Second Title',
         content: 'Class aptent taciti sociosqu ad litora torquent per conubia nostra',
-        overlayClassName: 'child-class',
         overlayClassName:'red',
       },
       {
@@ -216,7 +215,7 @@ const readTipOptions =  {
   };
 </script>
 
-<style>
+<style lang="scss">
 .read-tip-demo-icon {
   cursor: pointer;
   font-size: 16px;

--- a/packages/devui-vue/docs/index.md
+++ b/packages/devui-vue/docs/index.md
@@ -1,11 +1,41 @@
 ---
-home: true
-heroImage: /assets/devui-design.svg
-heroText: Vue DevUI
-tagline: 一个基于 DevUI Design 的 Vue3 组件库
-actionText: 快速开始
-actionLink: /quick-start/
-altActionText: Github
-altActionLink: https://github.com/DevCloudFE/vue-devui
-footer: MIT Licensed | Copyright © 2021-present DevUI
+layout: home
+hero:
+  name: Vue DevUI
+  text: 
+  tagline: 一个基于 DevUI Design 的 Vue3 组件库
+  image:
+    src: /assets/devui-design.svg
+    alt: Vue DevUI
+  actions:
+  - theme: brand
+    text: 开始
+    link: /quick-start/ 
+  - theme: alt 
+    text: Github
+    link: https://github.com/DevCloudFE/vue-devui
+
+features:
+- icon: 📦
+  title: 丰富的功能
+  details: 包含了55个简单、易用、灵活的高质量组件。。
+
+- icon: 🎨️
+  title: 主题
+  details: 支持主题定制，并内置无限、追光、蜜糖等5个漂亮的主题。
+
+- icon: 🔨
+  title: cli
+  details: 内置微脚手架，专注于组件的开发。
+
 ---
+
+<script setup>
+import Contributors from '@theme/components/Contributors.vue'
+import HomeFooter from '@theme/components/HomeFooter.vue'
+</script>
+
+<Contributors />
+<HomeFooter />
+
+

--- a/packages/devui-vue/package.json
+++ b/packages/devui-vue/package.json
@@ -96,8 +96,8 @@
     "vite": "^2.4.4",
     "vite-plugin-md": "^0.6.0",
     "vite-svg-loader": "^2.2.0",
-    "vitepress": "0.20.1",
-    "vitepress-theme-demoblock": "1.3.2",
+    "vitepress": "1.0.0-alpha.10",
+    "vitepress-theme-demoblock": "1.4.2",
     "vue-tsc": "^0.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
       vite: ^2.4.4
       vite-plugin-md: ^0.6.0
       vite-svg-loader: ^2.2.0
-      vitepress: 0.20.1
-      vitepress-theme-demoblock: 1.3.2
+      vitepress: 1.0.0-alpha.10
+      vitepress-theme-demoblock: 1.4.2
       vue: ^3.2.37
       vue-router: ^4.0.3
       vue-tsc: ^0.2.2
@@ -211,204 +211,9 @@ importers:
       vite: 2.8.4_sass@1.49.8
       vite-plugin-md: 0.6.7_vite@2.8.4
       vite-svg-loader: 2.2.0
-      vitepress: 0.20.1_sass@1.49.8
-      vitepress-theme-demoblock: 1.3.2_sass@1.49.8
+      vitepress: 1.0.0-alpha.10_sass@1.49.8
+      vitepress-theme-demoblock: 1.4.2_sass@1.49.8
       vue-tsc: 0.2.3_typescript@4.5.5
-
-  packages/devui-vue/build:
-    specifiers:
-      '@devui-design/icons': ^1.3.0
-      '@floating-ui/dom': ^0.4.4
-      '@types/lodash-es': ^4.17.4
-      '@vue/shared': ^3.2.33
-      '@vueuse/core': 8.9.4
-      async-validator: ^4.0.2
-      dayjs: ^1.11.3
-      devui-theme: ^0.0.1
-      fs-extra: ^10.0.0
-      lodash: ^4.17.21
-      lodash-es: ^4.17.20
-      mitt: ^3.0.0
-      vue-router: ^4.0.3
-    dependencies:
-      '@devui-design/icons': 1.3.0
-      '@floating-ui/dom': 0.4.4
-      '@types/lodash-es': 4.17.6
-      '@vue/shared': 3.2.37
-      '@vueuse/core': 8.9.4
-      async-validator: 4.0.7
-      dayjs: 1.11.3
-      devui-theme: link:../../devui-theme
-      fs-extra: 10.0.0
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-      mitt: 3.0.0
-      vue-router: 4.0.12
-
-  packages/devui-vue/build/alert:
-    specifiers: {}
-
-  packages/devui-vue/build/auto-complete:
-    specifiers: {}
-
-  packages/devui-vue/build/avatar:
-    specifiers: {}
-
-  packages/devui-vue/build/badge:
-    specifiers: {}
-
-  packages/devui-vue/build/button:
-    specifiers: {}
-
-  packages/devui-vue/build/card:
-    specifiers: {}
-
-  packages/devui-vue/build/checkbox:
-    specifiers: {}
-
-  packages/devui-vue/build/collapse:
-    specifiers: {}
-
-  packages/devui-vue/build/countdown:
-    specifiers: {}
-
-  packages/devui-vue/build/date-picker-pro:
-    specifiers: {}
-
-  packages/devui-vue/build/drawer:
-    specifiers: {}
-
-  packages/devui-vue/build/dropdown:
-    specifiers: {}
-
-  packages/devui-vue/build/editable-select:
-    specifiers: {}
-
-  packages/devui-vue/build/form:
-    specifiers: {}
-
-  packages/devui-vue/build/fullscreen:
-    specifiers: {}
-
-  packages/devui-vue/build/grid:
-    specifiers: {}
-
-  packages/devui-vue/build/icon:
-    specifiers: {}
-
-  packages/devui-vue/build/image-preview:
-    specifiers: {}
-
-  packages/devui-vue/build/input:
-    specifiers: {}
-
-  packages/devui-vue/build/input-number:
-    specifiers: {}
-
-  packages/devui-vue/build/layout:
-    specifiers: {}
-
-  packages/devui-vue/build/loading:
-    specifiers: {}
-
-  packages/devui-vue/build/mention:
-    specifiers: {}
-
-  packages/devui-vue/build/menu:
-    specifiers: {}
-
-  packages/devui-vue/build/message:
-    specifiers: {}
-
-  packages/devui-vue/build/modal:
-    specifiers: {}
-
-  packages/devui-vue/build/notification:
-    specifiers: {}
-
-  packages/devui-vue/build/overlay:
-    specifiers: {}
-
-  packages/devui-vue/build/pagination:
-    specifiers: {}
-
-  packages/devui-vue/build/panel:
-    specifiers: {}
-
-  packages/devui-vue/build/popover:
-    specifiers: {}
-
-  packages/devui-vue/build/progress:
-    specifiers: {}
-
-  packages/devui-vue/build/radio:
-    specifiers: {}
-
-  packages/devui-vue/build/rate:
-    specifiers: {}
-
-  packages/devui-vue/build/result:
-    specifiers: {}
-
-  packages/devui-vue/build/ripple:
-    specifiers: {}
-
-  packages/devui-vue/build/search:
-    specifiers: {}
-
-  packages/devui-vue/build/select:
-    specifiers: {}
-
-  packages/devui-vue/build/skeleton:
-    specifiers: {}
-
-  packages/devui-vue/build/slider:
-    specifiers: {}
-
-  packages/devui-vue/build/splitter:
-    specifiers: {}
-
-  packages/devui-vue/build/statistic:
-    specifiers: {}
-
-  packages/devui-vue/build/status:
-    specifiers: {}
-
-  packages/devui-vue/build/steps:
-    specifiers: {}
-
-  packages/devui-vue/build/switch:
-    specifiers: {}
-
-  packages/devui-vue/build/table:
-    specifiers: {}
-
-  packages/devui-vue/build/tabs:
-    specifiers: {}
-
-  packages/devui-vue/build/tag:
-    specifiers: {}
-
-  packages/devui-vue/build/textarea:
-    specifiers: {}
-
-  packages/devui-vue/build/time-picker:
-    specifiers: {}
-
-  packages/devui-vue/build/time-select:
-    specifiers: {}
-
-  packages/devui-vue/build/timeline:
-    specifiers: {}
-
-  packages/devui-vue/build/tooltip:
-    specifiers: {}
-
-  packages/devui-vue/build/tree:
-    specifiers: {}
-
-  packages/devui-vue/build/upload:
-    specifiers: {}
 
 packages:
 
@@ -416,6 +221,12 @@ packages:
     resolution: {integrity: sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==}
     dependencies:
       '@algolia/autocomplete-shared': 1.5.2
+    dev: true
+
+  /@algolia/autocomplete-core/1.7.1:
+    resolution: {integrity: sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==}
+    dependencies:
+      '@algolia/autocomplete-shared': 1.7.1
     dev: true
 
   /@algolia/autocomplete-preset-algolia/1.5.2_algoliasearch@4.12.1:
@@ -428,8 +239,22 @@ packages:
       algoliasearch: 4.12.1
     dev: true
 
+  /@algolia/autocomplete-preset-algolia/1.7.1_algoliasearch@4.12.1:
+    resolution: {integrity: sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==}
+    peerDependencies:
+      '@algolia/client-search': ^4.9.1
+      algoliasearch: ^4.9.1
+    dependencies:
+      '@algolia/autocomplete-shared': 1.7.1
+      algoliasearch: 4.12.1
+    dev: true
+
   /@algolia/autocomplete-shared/1.5.2:
     resolution: {integrity: sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug==}
+    dev: true
+
+  /@algolia/autocomplete-shared/1.7.1:
+    resolution: {integrity: sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg==}
     dev: true
 
   /@algolia/cache-browser-local-storage/4.12.1:
@@ -2021,6 +1846,10 @@ packages:
     resolution: {integrity: sha512-QeWFCQOtS9D+Fi20liKsPXF2j/xWKh52e+P2Z1UATIdPMqmH6zoB2lcUz+cgv6PPVgWUtECeR6VSSUm71LT94w==}
     dev: true
 
+  /@docsearch/css/3.2.1:
+    resolution: {integrity: sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g==}
+    dev: true
+
   /@docsearch/js/1.0.0-alpha.28:
     resolution: {integrity: sha512-2g7aPhBy7FoEyeZW2G3LYHWVa8CFvqyozEz8PXt3hyywdFcmEIqmoCRwn8kboVftrOKCjtPcuLCewsaBoB3uiw==}
     dependencies:
@@ -2035,6 +1864,18 @@ packages:
     resolution: {integrity: sha512-1ap9Wz5oR/Z8yybaCZhsptXU43es3H52eEQUZtmzb8dUWyCW+3iXaKVB/qeMJOQWtggZ/WvZV3YknVIbCMR2dQ==}
     dependencies:
       '@docsearch/react': 3.0.0-alpha.50
+      preact: 10.6.6
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - react
+      - react-dom
+    dev: true
+
+  /@docsearch/js/3.2.1:
+    resolution: {integrity: sha512-H1PekEtSeS0msetR2YGGey2w7jQ2wAKfGODJvQTygSwMgUZ+2DHpzUgeDyEBIXRIfaBcoQneqrzsljM62pm6Xg==}
+    dependencies:
+      '@docsearch/react': 3.2.1
       preact: 10.6.6
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -2070,6 +1911,28 @@ packages:
       - '@algolia/client-search'
     dev: true
 
+  /@docsearch/react/3.2.1:
+    resolution: {integrity: sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@algolia/autocomplete-core': 1.7.1
+      '@algolia/autocomplete-preset-algolia': 1.7.1_algoliasearch@4.12.1
+      '@docsearch/css': 3.2.1
+      algoliasearch: 4.12.1
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+    dev: true
+
   /@emmetio/abbreviation/2.2.3:
     resolution: {integrity: sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==}
     dependencies:
@@ -2085,6 +1948,26 @@ packages:
   /@emmetio/scanner/1.0.0:
     resolution: {integrity: sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==}
     dev: true
+
+  /@esbuild/android-arm/0.15.8:
+    resolution: {integrity: sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.8:
+    resolution: {integrity: sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint/eslintrc/0.4.3:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -2502,7 +2385,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       postcss: 7.0.39
-      postcss-syntax: 0.36.2_postcss@7.0.39
+      postcss-syntax: 0.36.2_5111c4e3f61982716b7e3f1c84e1f773
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2515,7 +2398,7 @@ packages:
       postcss-syntax: '>=0.36.2'
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2_postcss@7.0.39
+      postcss-syntax: 0.36.2_5111c4e3f61982716b7e3f1c84e1f773
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -2710,6 +2593,10 @@ packages:
     resolution: {integrity: sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==}
     dev: false
 
+  /@types/web-bluetooth/0.0.15:
+    resolution: {integrity: sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==}
+    dev: true
+
   /@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
     dev: true
@@ -2866,6 +2753,17 @@ packages:
       vue: 3.2.31
     dev: true
 
+  /@vitejs/plugin-vue/3.1.0_vite@3.1.3+vue@3.2.39:
+    resolution: {integrity: sha512-fmxtHPjSOEIRg6vHYDaem+97iwCUg/uSIaTzp98lhELt2ISOQuDo2hbkBdXod0g15IhfPMQmAxh4heUks2zvDA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 3.1.3_sass@1.49.8
+      vue: 3.2.39
+    dev: true
+
   /@volar/code-gen/0.27.24:
     resolution: {integrity: sha512-s4j/QqOZUW03PeD6LmVYI00Q1C3CfJEOePDOQwDvCTUov4lFk0iSBtFyYhjlLyQ1pdtV1+TDTErkj2aMQtc4PA==}
     dependencies:
@@ -3017,6 +2915,15 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
+  /@vue/compiler-core/3.2.39:
+    resolution: {integrity: sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==}
+    dependencies:
+      '@babel/parser': 7.17.3
+      '@vue/shared': 3.2.39
+      estree-walker: 2.0.2
+      source-map: 0.6.1
+    dev: true
+
   /@vue/compiler-dom/3.2.31:
     resolution: {integrity: sha512-60zIlFfzIDf3u91cqfqy9KhCKIJgPeqxgveH2L+87RcGU/alT6BRrk5JtUso0OibH3O7NXuNOQ0cDc9beT0wrg==}
     dependencies:
@@ -3028,6 +2935,13 @@ packages:
     dependencies:
       '@vue/compiler-core': 3.2.37
       '@vue/shared': 3.2.37
+
+  /@vue/compiler-dom/3.2.39:
+    resolution: {integrity: sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==}
+    dependencies:
+      '@vue/compiler-core': 3.2.39
+      '@vue/shared': 3.2.39
+    dev: true
 
   /@vue/compiler-sfc/3.2.31:
     resolution: {integrity: sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==}
@@ -3057,6 +2971,21 @@ packages:
       postcss: 8.4.6
       source-map: 0.6.1
 
+  /@vue/compiler-sfc/3.2.39:
+    resolution: {integrity: sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==}
+    dependencies:
+      '@babel/parser': 7.17.3
+      '@vue/compiler-core': 3.2.39
+      '@vue/compiler-dom': 3.2.39
+      '@vue/compiler-ssr': 3.2.39
+      '@vue/reactivity-transform': 3.2.39
+      '@vue/shared': 3.2.39
+      estree-walker: 2.0.2
+      magic-string: 0.25.7
+      postcss: 8.4.16
+      source-map: 0.6.1
+    dev: true
+
   /@vue/compiler-ssr/3.2.31:
     resolution: {integrity: sha512-mjN0rqig+A8TVDnsGPYJM5dpbjlXeHUm2oZHZwGyMYiGT/F4fhJf/cXy8QpjnLQK4Y9Et4GWzHn9PS8AHUnSkw==}
     dependencies:
@@ -3069,9 +2998,20 @@ packages:
       '@vue/compiler-dom': 3.2.37
       '@vue/shared': 3.2.37
 
+  /@vue/compiler-ssr/3.2.39:
+    resolution: {integrity: sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.39
+      '@vue/shared': 3.2.39
+    dev: true
+
   /@vue/devtools-api/6.0.12:
     resolution: {integrity: sha512-iO/4FIezHKXhiDBdKySCvJVh8/mZPxHpiQrTy+PXVqJZgpTPTdHy4q8GXulaY+UKEagdkBb0onxNQZ0LNiqVhw==}
     dev: false
+
+  /@vue/devtools-api/6.2.1:
+    resolution: {integrity: sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ==}
+    dev: true
 
   /@vue/reactivity-transform/3.2.31:
     resolution: {integrity: sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==}
@@ -3091,6 +3031,16 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.25.7
 
+  /@vue/reactivity-transform/3.2.39:
+    resolution: {integrity: sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==}
+    dependencies:
+      '@babel/parser': 7.17.3
+      '@vue/compiler-core': 3.2.39
+      '@vue/shared': 3.2.39
+      estree-walker: 2.0.2
+      magic-string: 0.25.7
+    dev: true
+
   /@vue/reactivity/3.2.31:
     resolution: {integrity: sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==}
     dependencies:
@@ -3101,12 +3051,17 @@ packages:
     dependencies:
       '@vue/shared': 3.2.37
 
+  /@vue/reactivity/3.2.39:
+    resolution: {integrity: sha512-vlaYX2a3qMhIZfrw3Mtfd+BuU+TZmvDrPMa+6lpfzS9k/LnGxkSuf0fhkP0rMGfiOHPtyKoU9OJJJFGm92beVQ==}
+    dependencies:
+      '@vue/shared': 3.2.39
+    dev: true
+
   /@vue/runtime-core/3.2.31:
     resolution: {integrity: sha512-Kcog5XmSY7VHFEMuk4+Gap8gUssYMZ2+w+cmGI6OpZWYOEIcbE0TPzzPHi+8XTzAgx1w/ZxDFcXhZeXN5eKWsA==}
     dependencies:
       '@vue/reactivity': 3.2.31
       '@vue/shared': 3.2.31
-    dev: false
 
   /@vue/runtime-core/3.2.37:
     resolution: {integrity: sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==}
@@ -3114,13 +3069,19 @@ packages:
       '@vue/reactivity': 3.2.37
       '@vue/shared': 3.2.37
 
+  /@vue/runtime-core/3.2.39:
+    resolution: {integrity: sha512-xKH5XP57JW5JW+8ZG1khBbuLakINTgPuINKL01hStWLTTGFOrM49UfCFXBcFvWmSbci3gmJyLl2EAzCaZWsx8g==}
+    dependencies:
+      '@vue/reactivity': 3.2.39
+      '@vue/shared': 3.2.39
+    dev: true
+
   /@vue/runtime-dom/3.2.31:
     resolution: {integrity: sha512-N+o0sICVLScUjfLG7u9u5XCjvmsexAiPt17GNnaWHJUfsKed5e85/A3SWgKxzlxx2SW/Hw7RQxzxbXez9PtY3g==}
     dependencies:
       '@vue/runtime-core': 3.2.31
       '@vue/shared': 3.2.31
       csstype: 2.6.19
-    dev: false
 
   /@vue/runtime-dom/3.2.37:
     resolution: {integrity: sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==}
@@ -3128,6 +3089,14 @@ packages:
       '@vue/runtime-core': 3.2.37
       '@vue/shared': 3.2.37
       csstype: 2.6.19
+
+  /@vue/runtime-dom/3.2.39:
+    resolution: {integrity: sha512-4G9AEJP+sLhsqf5wXcyKVWQKUhI+iWfy0hWQgea+CpaTD7BR0KdQzvoQdZhwCY6B3oleSyNLkLAQwm0ya/wNoA==}
+    dependencies:
+      '@vue/runtime-core': 3.2.39
+      '@vue/shared': 3.2.39
+      csstype: 2.6.19
+    dev: true
 
   /@vue/server-renderer/3.2.31_vue@3.2.31:
     resolution: {integrity: sha512-8CN3Zj2HyR2LQQBHZ61HexF5NReqngLT3oahyiVRfSSvak+oAvVmu8iNLSu6XR77Ili2AOpnAt1y8ywjjqtmkg==}
@@ -3137,7 +3106,6 @@ packages:
       '@vue/compiler-ssr': 3.2.31
       '@vue/shared': 3.2.31
       vue: 3.2.31
-    dev: false
 
   /@vue/server-renderer/3.2.37_vue@3.2.37:
     resolution: {integrity: sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==}
@@ -3148,6 +3116,16 @@ packages:
       '@vue/shared': 3.2.37
       vue: 3.2.37
 
+  /@vue/server-renderer/3.2.39_vue@3.2.39:
+    resolution: {integrity: sha512-1yn9u2YBQWIgytFMjz4f/t0j43awKytTGVptfd3FtBk76t1pd8mxbek0G/DrnjJhd2V7mSTb5qgnxMYt8Z5iSQ==}
+    peerDependencies:
+      vue: 3.2.39
+    dependencies:
+      '@vue/compiler-ssr': 3.2.39
+      '@vue/shared': 3.2.39
+      vue: 3.2.39
+    dev: true
+
   /@vue/shared/3.2.31:
     resolution: {integrity: sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ==}
 
@@ -3157,6 +3135,10 @@ packages:
 
   /@vue/shared/3.2.37:
     resolution: {integrity: sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==}
+
+  /@vue/shared/3.2.39:
+    resolution: {integrity: sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==}
+    dev: true
 
   /@vue/test-utils/2.0.0-rc.17_vue@3.2.37:
     resolution: {integrity: sha512-7LHZKsFRV/HqDoMVY+cJamFzgHgsrmQFalROHC5FMWrzPzd+utG5e11krj1tVsnxYufGA2ABShX4nlcHXED+zQ==}
@@ -3262,23 +3244,6 @@ packages:
       - supports-color
     dev: true
 
-  /@vueuse/core/8.9.4:
-    resolution: {integrity: sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: ^2.6.0 || ^3.2.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      '@types/web-bluetooth': 0.0.14
-      '@vueuse/metadata': 8.9.4
-      '@vueuse/shared': 8.9.4
-      vue-demi: 0.12.1
-    dev: false
-
   /@vueuse/core/8.9.4_vue@3.2.37:
     resolution: {integrity: sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==}
     peerDependencies:
@@ -3297,23 +3262,25 @@ packages:
       vue-demi: 0.12.1_vue@3.2.37
     dev: false
 
+  /@vueuse/core/9.2.0_vue@3.2.39:
+    resolution: {integrity: sha512-/MZ6qpz6uSyaXrtoeBWQzAKRG3N7CvfVWvQxiM3ei3Xe5ydOjjtVbo7lGl9p8dECV93j7W8s63A8H0kFLpLyxg==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.15
+      '@vueuse/metadata': 9.2.0
+      '@vueuse/shared': 9.2.0_vue@3.2.39
+      vue-demi: 0.12.1_vue@3.2.39
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
+
   /@vueuse/metadata/8.9.4:
     resolution: {integrity: sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw==}
     dev: false
 
-  /@vueuse/shared/8.9.4:
-    resolution: {integrity: sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==}
-    peerDependencies:
-      '@vue/composition-api': ^1.1.0
-      vue: ^2.6.0 || ^3.2.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      vue-demi: 0.12.1
-    dev: false
+  /@vueuse/metadata/9.2.0:
+    resolution: {integrity: sha512-exN4KE6iquxDCdt72BgEhb3tlOpECtD61AUdXnUqBTIUCl70x1Ar/QXo3bYcvxmdMS2/peQyfeTzBjRTpvL5xw==}
+    dev: true
 
   /@vueuse/shared/8.9.4_vue@3.2.37:
     resolution: {integrity: sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==}
@@ -3329,6 +3296,15 @@ packages:
       vue: 3.2.37
       vue-demi: 0.12.1_vue@3.2.37
     dev: false
+
+  /@vueuse/shared/9.2.0_vue@3.2.39:
+    resolution: {integrity: sha512-NnRp/noSWuXW0dKhZK5D0YLrDi0nmZ18UeEgwXQq7Ul5TTP93lcNnKjrHtd68j2xFB/l59yPGFlCryL692bnrA==}
+    dependencies:
+      vue-demi: 0.12.1_vue@3.2.39
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
 
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -3801,6 +3777,10 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
+  /body-scroll-lock/4.0.0-beta.0:
+    resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
+    dev: true
+
   /boolbase/1.0.0:
     resolution: {integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=}
     dev: true
@@ -3853,7 +3833,7 @@ packages:
     dev: true
 
   /bytes/3.0.0:
-    resolution: {integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=}
+    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
     dev: true
 
@@ -4142,6 +4122,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /concat-map/0.0.1:
@@ -4455,12 +4437,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -4544,7 +4536,7 @@ packages:
     dev: true
 
   /diacritics/1.3.0:
-    resolution: {integrity: sha1-PvqHMj67hj5mls67AILUj/PW96E=}
+    resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
     dev: true
 
   /didyoumean/1.2.2:
@@ -4740,6 +4732,17 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /esbuild-android-64/0.15.8:
+    resolution: {integrity: sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.13.15:
     resolution: {integrity: sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==}
     cpu: [arm64]
@@ -4750,6 +4753,15 @@ packages:
 
   /esbuild-android-arm64/0.14.23:
     resolution: {integrity: sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.8:
+    resolution: {integrity: sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4774,6 +4786,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.15.8:
+    resolution: {integrity: sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.13.15:
     resolution: {integrity: sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==}
     cpu: [arm64]
@@ -4784,6 +4805,15 @@ packages:
 
   /esbuild-darwin-arm64/0.14.23:
     resolution: {integrity: sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.8:
+    resolution: {integrity: sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4808,6 +4838,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.15.8:
+    resolution: {integrity: sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.13.15:
     resolution: {integrity: sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==}
     cpu: [arm64]
@@ -4818,6 +4857,15 @@ packages:
 
   /esbuild-freebsd-arm64/0.14.23:
     resolution: {integrity: sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.8:
+    resolution: {integrity: sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4842,6 +4890,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.15.8:
+    resolution: {integrity: sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.13.15:
     resolution: {integrity: sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==}
     cpu: [x64]
@@ -4852,6 +4909,15 @@ packages:
 
   /esbuild-linux-64/0.14.23:
     resolution: {integrity: sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.8:
+    resolution: {integrity: sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -4876,6 +4942,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.15.8:
+    resolution: {integrity: sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.13.15:
     resolution: {integrity: sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==}
     cpu: [arm64]
@@ -4886,6 +4961,15 @@ packages:
 
   /esbuild-linux-arm64/0.14.23:
     resolution: {integrity: sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.8:
+    resolution: {integrity: sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -4910,6 +4994,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.15.8:
+    resolution: {integrity: sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.13.15:
     resolution: {integrity: sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==}
     cpu: [ppc64]
@@ -4927,6 +5020,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-ppc64le/0.15.8:
+    resolution: {integrity: sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-riscv64/0.14.23:
     resolution: {integrity: sha512-fbL3ggK2wY0D8I5raPIMPhpCvODFE+Bhb5QGtNP3r5aUsRR6TQV+ZBXIaw84iyvKC8vlXiA4fWLGhghAd/h/Zg==}
     engines: {node: '>=12'}
@@ -4936,8 +5038,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.15.8:
+    resolution: {integrity: sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.23:
     resolution: {integrity: sha512-GHMDCyfy7+FaNSO8RJ8KCFsnax8fLUsOrj9q5Gi2JmZMY0Zhp75keb5abTFCq2/Oy6KVcT0Dcbyo/bFb4rIFJA==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.8:
+    resolution: {integrity: sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -4962,6 +5082,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.15.8:
+    resolution: {integrity: sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.13.15:
     resolution: {integrity: sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==}
     cpu: [x64]
@@ -4972,6 +5101,15 @@ packages:
 
   /esbuild-openbsd-64/0.14.23:
     resolution: {integrity: sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.15.8:
+    resolution: {integrity: sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -5003,6 +5141,23 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.15.8:
+    resolution: {integrity: sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-wasm/0.15.8:
+    resolution: {integrity: sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.13.15:
     resolution: {integrity: sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==}
     cpu: [ia32]
@@ -5013,6 +5168,15 @@ packages:
 
   /esbuild-windows-32/0.14.23:
     resolution: {integrity: sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.15.8:
+    resolution: {integrity: sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -5037,6 +5201,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.15.8:
+    resolution: {integrity: sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.13.15:
     resolution: {integrity: sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==}
     cpu: [arm64]
@@ -5047,6 +5220,15 @@ packages:
 
   /esbuild-windows-arm64/0.14.23:
     resolution: {integrity: sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.8:
+    resolution: {integrity: sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -5111,13 +5293,43 @@ packages:
       esbuild-windows-arm64: 0.14.23
     dev: true
 
+  /esbuild/0.15.8:
+    resolution: {integrity: sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.8
+      '@esbuild/linux-loong64': 0.15.8
+      esbuild-android-64: 0.15.8
+      esbuild-android-arm64: 0.15.8
+      esbuild-darwin-64: 0.15.8
+      esbuild-darwin-arm64: 0.15.8
+      esbuild-freebsd-64: 0.15.8
+      esbuild-freebsd-arm64: 0.15.8
+      esbuild-linux-32: 0.15.8
+      esbuild-linux-64: 0.15.8
+      esbuild-linux-arm: 0.15.8
+      esbuild-linux-arm64: 0.15.8
+      esbuild-linux-mips64le: 0.15.8
+      esbuild-linux-ppc64le: 0.15.8
+      esbuild-linux-riscv64: 0.15.8
+      esbuild-linux-s390x: 0.15.8
+      esbuild-netbsd-64: 0.15.8
+      esbuild-openbsd-64: 0.15.8
+      esbuild-sunos-64: 0.15.8
+      esbuild-windows-32: 0.15.8
+      esbuild-windows-64: 0.15.8
+      esbuild-windows-arm64: 0.15.8
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
     dev: true
 
   /escape-html/1.0.3:
-    resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
     dev: true
 
   /escape-string-regexp/1.0.5:
@@ -5153,21 +5365,44 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_a2e9ad6bb1d60475ebc0dfc5e76a2549:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-import/2.25.4_eslint@7.32.0:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
@@ -5175,7 +5410,7 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_a2e9ad6bb1d60475ebc0dfc5e76a2549
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
@@ -5183,6 +5418,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-vue/7.20.0_eslint@7.32.0:
@@ -6048,6 +6287,12 @@ packages:
   /is-callable/1.2.4:
     resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-core-module/2.10.0:
+    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+    dependencies:
+      has: 1.0.3
     dev: true
 
   /is-core-module/2.8.1:
@@ -7332,6 +7577,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
@@ -7787,7 +8038,7 @@ packages:
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2_postcss@7.0.39
+      postcss-syntax: 0.36.2_5111c4e3f61982716b7e3f1c84e1f773
     dev: true
 
   /postcss-less/3.1.4:
@@ -7834,12 +8085,31 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-syntax/0.36.2_postcss@7.0.39:
+  /postcss-syntax/0.36.2_5111c4e3f61982716b7e3f1c84e1f773:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
+      postcss-html: '*'
+      postcss-jsx: '*'
+      postcss-less: '*'
+      postcss-markdown: '*'
+      postcss-scss: '*'
+    peerDependenciesMeta:
+      postcss-html:
+        optional: true
+      postcss-jsx:
+        optional: true
+      postcss-less:
+        optional: true
+      postcss-markdown:
+        optional: true
+      postcss-scss:
+        optional: true
     dependencies:
       postcss: 7.0.39
+      postcss-html: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
     dev: true
 
   /postcss-value-parser/4.2.0:
@@ -7852,6 +8122,15 @@ packages:
     dependencies:
       picocolors: 0.2.1
       source-map: 0.6.1
+    dev: true
+
+  /postcss/8.4.16:
+    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
     dev: true
 
   /postcss/8.4.6:
@@ -8265,6 +8544,15 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.10.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
   /restore-cursor/3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -8291,6 +8579,14 @@ packages:
 
   /rollup/2.67.3:
     resolution: {integrity: sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup/2.78.1:
+    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8430,6 +8726,14 @@ packages:
       glob: 7.2.0
       interpret: 1.4.0
       rechoir: 0.6.2
+    dev: true
+
+  /shiki/0.11.1:
+    resolution: {integrity: sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==}
+    dependencies:
+      jsonc-parser: 3.0.0
+      vscode-oniguruma: 1.6.2
+      vscode-textmate: 6.0.0
     dev: true
 
   /side-channel/1.0.4:
@@ -8753,7 +9057,7 @@ packages:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.0.9
-      postcss-syntax: 0.36.2_postcss@7.0.39
+      postcss-syntax: 0.36.2_5111c4e3f61982716b7e3f1c84e1f773
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -8767,6 +9071,8 @@ packages:
       v8-compile-cache: 2.3.0
       write-file-atomic: 3.0.3
     transitivePeerDependencies:
+      - postcss-jsx
+      - postcss-markdown
       - supports-color
     dev: true
 
@@ -9187,7 +9493,7 @@ packages:
     dev: true
 
   /vary/1.1.2:
-    resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
     dev: true
 
@@ -9273,8 +9579,36 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitepress-theme-demoblock/1.3.2_sass@1.49.8:
-    resolution: {integrity: sha512-uyzdb28sq2hSNzU4KeITNayWNPYUqvUWcahcqQZVvAoPlSr1tF9vGraRQWEhAFW//MII3tM/mncYLfICJfmISw==}
+  /vite/3.1.3_sass@1.49.8:
+    resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.15.8
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.78.1
+      sass: 1.49.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vitepress-theme-demoblock/1.4.2_sass@1.49.8:
+    resolution: {integrity: sha512-OMIRg1JJI8NvBVLFu2G0cd+gT5IzXZfTsV7yws7GfRXZE3Q4qLO5cR1+ngNnFZw44ID1oLk+Yu9HZM+AJYtgWA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -9304,8 +9638,8 @@ packages:
       '@docsearch/js': 1.0.0-alpha.28
       '@types/markdown-it': 12.2.3
       '@vitejs/plugin-vue': 1.10.2_vite@2.8.4
-      '@vue/compiler-sfc': 3.2.37
-      '@vue/server-renderer': 3.2.37_vue@3.2.37
+      '@vue/compiler-sfc': 3.2.39
+      '@vue/server-renderer': 3.2.39_vue@3.2.39
       chalk: 4.1.2
       compression: 1.7.4
       debug: 4.3.3
@@ -9326,7 +9660,7 @@ packages:
       prismjs: 1.27.0
       sirv: 1.0.19
       vite: 2.8.4_sass@1.49.8
-      vue: 3.2.37
+      vue: 3.2.39
     transitivePeerDependencies:
       - less
       - react
@@ -9336,23 +9670,29 @@ packages:
       - supports-color
     dev: true
 
-  /vitepress/0.20.1_sass@1.49.8:
-    resolution: {integrity: sha512-2SOlvRv0bvPrQ3RPtp7Fh/G1MKidrsgAgYz18OvV+nIJb9iiYo0GUVHKN3OYswMh+vH78NyTeA1Q5v4YJ/H9LQ==}
-    engines: {node: '>=12.0.0'}
+  /vitepress/1.0.0-alpha.10_sass@1.49.8:
+    resolution: {integrity: sha512-RGPU+YApj2jaYplAIJUe+2qlDks9FzPX1QGK+7NdGByeCCVZg6z9eYWjjvfvA/sgCtG3yeJE/4/jCwlv4Y8bVw==}
     hasBin: true
     dependencies:
-      '@docsearch/css': 1.0.0-alpha.28
-      '@docsearch/js': 1.0.0-alpha.28
-      '@vitejs/plugin-vue': 1.10.2_vite@2.8.4
-      prismjs: 1.27.0
-      vite: 2.8.4_sass@1.49.8
-      vue: 3.2.37
+      '@docsearch/css': 3.2.1
+      '@docsearch/js': 3.2.1
+      '@vitejs/plugin-vue': 3.1.0_vite@3.1.3+vue@3.2.39
+      '@vue/devtools-api': 6.2.1
+      '@vueuse/core': 9.2.0_vue@3.2.39
+      body-scroll-lock: 4.0.0-beta.0
+      shiki: 0.11.1
+      vite: 3.1.3_sass@1.49.8
+      vue: 3.2.39
     transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - '@vue/composition-api'
       - less
       - react
       - react-dom
       - sass
       - stylus
+      - terser
     dev: true
 
   /void-elements/3.1.0:
@@ -9423,6 +9763,10 @@ packages:
     resolution: {integrity: sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==}
     dev: true
 
+  /vscode-oniguruma/1.6.2:
+    resolution: {integrity: sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==}
+    dev: true
+
   /vscode-pug-languageservice/0.27.24:
     resolution: {integrity: sha512-GSvsFB+rPhAD7cBlEKCVNNsFGIaOnp/0zyLw3WpYbXY24vJZafXu1kHvtYaaQXJRnIhqp5EI5p+EqpdI3hTBnw==}
     dependencies:
@@ -9445,6 +9789,10 @@ packages:
       pug-lexer: 5.0.1
       pug-parser: 6.0.0
       vscode-languageserver: 8.0.0-next.8
+    dev: true
+
+  /vscode-textmate/6.0.0:
+    resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
     dev: true
 
   /vscode-typescript-languageservice/0.27.25:
@@ -9526,19 +9874,6 @@ packages:
     deprecated: This package has been renamed to @vscode/web-custom-data, please update to the new name
     dev: true
 
-  /vue-demi/0.12.1:
-    resolution: {integrity: sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-    dev: false
-
   /vue-demi/0.12.1_vue@3.2.37:
     resolution: {integrity: sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==}
     engines: {node: '>=12'}
@@ -9553,6 +9888,21 @@ packages:
     dependencies:
       vue: 3.2.37
     dev: false
+
+  /vue-demi/0.12.1_vue@3.2.39:
+    resolution: {integrity: sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.2.39
+    dev: true
 
   /vue-eslint-parser/7.11.0_eslint@7.32.0:
     resolution: {integrity: sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==}
@@ -9571,14 +9921,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /vue-router/4.0.12:
-    resolution: {integrity: sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      '@vue/devtools-api': 6.0.12
-    dev: false
 
   /vue-router/4.0.12_vue@3.2.37:
     resolution: {integrity: sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==}
@@ -9618,7 +9960,6 @@ packages:
       '@vue/runtime-dom': 3.2.31
       '@vue/server-renderer': 3.2.31_vue@3.2.31
       '@vue/shared': 3.2.31
-    dev: false
 
   /vue/3.2.37:
     resolution: {integrity: sha512-bOKEZxrm8Eh+fveCqS1/NkG/n6aMidsI6hahas7pa0w/l7jkbssJVsRhVDs07IdDq7h9KHswZOgItnwJAgtVtQ==}
@@ -9628,6 +9969,16 @@ packages:
       '@vue/runtime-dom': 3.2.37
       '@vue/server-renderer': 3.2.37_vue@3.2.37
       '@vue/shared': 3.2.37
+
+  /vue/3.2.39:
+    resolution: {integrity: sha512-tRkguhRTw9NmIPXhzk21YFBqXHT2t+6C6wPOgQ50fcFVWnPdetmRqbmySRHznrYjX2E47u0cGlKGcxKZJ38R/g==}
+    dependencies:
+      '@vue/compiler-dom': 3.2.39
+      '@vue/compiler-sfc': 3.2.39
+      '@vue/runtime-dom': 3.2.39
+      '@vue/server-renderer': 3.2.39_vue@3.2.39
+      '@vue/shared': 3.2.39
+    dev: true
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}


### PR DESCRIPTION
1. vitepress更新到1.x

# 问题
1. vitepress-theme-demoblock 插件对最新版本的vitepress 未做更新 导致1.10上使用会报错
2. 原来实现是通过修改 文件来实现 国际化 主题切换都是在 自定义文件实现，是否考虑其他方式
3. 更新完后样式存在一些问题，应该是之前某些样式文件没有应用