### PR TITLE
fix(date-picker-pro): 修复 range-date-picker-pro v-model 测试用例错误

### DIFF
--- a/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/range-date-picker-pro.spec.tsx
@@ -126,9 +126,16 @@ describe('range-date-picker-pro test', () => {
     });
 
     const container = wrapper.find(baseClass);
-    datePickerProValue.value[0] = new Date();
+
+    const date = new Date();
+    datePickerProValue.value[0] = date;
     const time = 5 * 24 * 3600 * 1000;
-    datePickerProValue.value[1] = new Date().getDate() > 20 ? new Date() : new Date(new Date().getTime() + time);
+
+    const todayIndex = getDateIndex(date);
+    // todayIndex 大于 20 赋值当前日期 否则加五天 对应下方getSelectedIndex逻辑
+    datePickerProValue.value[1] = todayIndex > 20 ? new Date() : new Date(new Date().getTime() + time);
+    const selectIndex = getSelectedIndex(todayIndex, 5);
+
     await nextTick();
     const inputs = container.findAll('input');
     await inputs[0].trigger('focus');
@@ -138,13 +145,11 @@ describe('range-date-picker-pro test', () => {
     expect(pickerPanel).toBeTruthy();
     const tableMonthItems = pickerPanel?.querySelectorAll(tableMonthClass);
 
-    const date = new Date();
-    const todayIndx = getDateIndex(date);
-    const selectIndex = getSelectedIndex(todayIndx, 5);
+
     // 虚拟列表 当前面板呈现月为虚拟列表的第二个tableMonthItem
     const monthContentContainer = tableMonthItems?.[1].querySelector(datePickerNs.e('table-month-content'));
     const Items = monthContentContainer?.getElementsByTagName('td');
-    expect(Items?.[todayIndx].classList).toContain(noDotDatePickerNs.e('table-date-start'));
+    expect(Items?.[todayIndex].classList).toContain(noDotDatePickerNs.e('table-date-start'));
 
     await inputs[1].trigger('focus');
     await nextTick();
@@ -170,7 +175,8 @@ describe('range-date-picker-pro test', () => {
             onToggleChange={onToggleChange}
             onConfirmEvent={onConfirmEvent}
             onFocus={onFocus}
-            onBlur={onBlur}></DRangeDatePickerPro>
+            onBlur={onBlur}
+          ></DRangeDatePickerPro>
         );
       },
     });
@@ -277,13 +283,15 @@ describe('range-date-picker-pro test', () => {
                       color="primary"
                       onClick={() => {
                         setDate(-30);
-                      }}>
+                      }}
+                    >
                       一个月前
                     </DButton>
                   </li>
                 </ul>
               ),
-            }}></DRangeDatePickerPro>
+            }}
+          ></DRangeDatePickerPro>
         );
       },
     });
@@ -334,7 +342,8 @@ describe('range-date-picker-pro test', () => {
                   </d-button>
                 </div>
               ),
-            }}></DRangeDatePickerPro>
+            }}
+          ></DRangeDatePickerPro>
         );
       },
     });
@@ -379,7 +388,8 @@ describe('range-date-picker-pro test', () => {
           <DRangeDatePickerPro
             v-model={datePickerProValue.value}
             calendarRange={calendarRange}
-            limitDateRange={limitDateRange.value}></DRangeDatePickerPro>
+            limitDateRange={limitDateRange.value}
+          ></DRangeDatePickerPro>
         );
       },
     });

--- a/packages/devui-vue/devui/date-picker-pro/__tests__/utils.ts
+++ b/packages/devui-vue/devui/date-picker-pro/__tests__/utils.ts
@@ -6,9 +6,9 @@ export const getDateIndex = (date: Date): number => {
 };
 
 export const getSelectedIndex = (todayIndex: number, intervalDay = 1): number => {
-  return todayIndex > 20 ? todayIndex - 1 : todayIndex + intervalDay;
+  return todayIndex > 20 ? todayIndex : todayIndex + intervalDay;
 };
 
 export const getSelectedDate = (todayIndex: number, date: Date, intervalDay = 1): string => {
-  return todayIndex > 20 ? dayjs(date).subtract(1, 'day').format(DATE_FORMAT) : dayjs(date).add(intervalDay, 'day').format(DATE_FORMAT);
+  return todayIndex > 20 ? dayjs(date).format(DATE_FORMAT) : dayjs(date).add(intervalDay, 'day').format(DATE_FORMAT);
 };


### PR DESCRIPTION
+ 修复 range-date-picker-pro v-model 测试用例错误，设置日期时大于20设置为当前日期，所以utils相关函数不应该大于20时-1

<img width="1355" alt="截屏2022-10-28 下午10 21 14" src="https://user-images.githubusercontent.com/52314078/198641350-32c5281b-18ce-477d-b8fd-61a952f90fe0.png">
这个 getDateIndex 函数为什么要这么计算呢？哪位大佬明白的告知下