### PR TITLE
switch 组件 size 向标准统一 (#1199)

### DIFF
--- a/packages/devui-vue/devui/switch/__tests__/switch.spec.ts
+++ b/packages/devui-vue/devui/switch/__tests__/switch.spec.ts
@@ -3,12 +3,15 @@ import { ref, nextTick } from 'vue';
 import DSwitch from '../src/switch';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 
-const ns = useNamespace('switch', false);
-const baseClass = ns.b();
-const disabledClass = ns.m('disabled');
-const checkedClass = ns.m('checked');
-const smSizeClass = ns.m('sm');
-const lgSizeClass = ns.m('lg');
+const ns = useNamespace('switch', true);
+const notDotNs = useNamespace('switch', false);
+
+const baseClass = notDotNs.b();
+const containerClass = ns.e('wrapper');
+const disabledClass = notDotNs.m('disabled');
+const checkedClass = notDotNs.m('checked');
+const smSizeClass = notDotNs.m('sm');
+const lgSizeClass = notDotNs.m('lg');
 
 describe('d-switch', () => {
   it('switch render work', async () => {
@@ -26,12 +29,16 @@ describe('d-switch', () => {
     });
 
     expect(wrapper.classes()).toContain(baseClass);
-    expect(wrapper.classes()).not.toContain(checkedClass);
+    const container = wrapper.find(containerClass);
+    expect(container.exists()).toBeTruthy();
+    expect(container.classes()).not.toContain(checkedClass);
 
     checked.value = true;
     await nextTick();
 
-    expect(wrapper.classes()).toContain(checkedClass);
+    expect(container.classes()).toContain(checkedClass);
+
+    wrapper.unmount();
   });
 
   it('switch disabled work', async () => {
@@ -43,18 +50,21 @@ describe('d-switch', () => {
       },
     });
 
-    expect(wrapper.classes()).toContain(disabledClass);
+    const container = wrapper.find(containerClass);
+    expect(container.classes()).toContain(disabledClass);
 
-    await wrapper.trigger('click');
+    await container.trigger('click');
     expect(onChange).toBeCalledTimes(0);
 
     await wrapper.setProps({
       disabled: false,
     });
-    await wrapper.trigger('click');
+    await container.trigger('click');
 
-    expect(wrapper.classes()).not.toContain(disabledClass);
+    expect(container.classes()).not.toContain(disabledClass);
     expect(onChange).toBeCalledTimes(1);
+
+    wrapper.unmount();
   });
 
   it('switch size work', async () => {
@@ -71,6 +81,8 @@ describe('d-switch', () => {
     });
     expect(wrapper.classes()).not.toContain(smSizeClass);
     expect(wrapper.classes()).toContain(lgSizeClass);
+
+    wrapper.unmount();
   });
 
   it('switch beforeChange work', async () => {
@@ -83,14 +95,17 @@ describe('d-switch', () => {
       },
     });
 
-    await wrapper.trigger('click');
+    const container = wrapper.find(containerClass);
+    await container.trigger('click');
     expect(beforeChange).toBeCalledTimes(1);
     expect(onChange).toBeCalledTimes(0);
 
     beforeChange.mockReturnValue(true);
-    await wrapper.trigger('click');
+    await container.trigger('click');
     expect(beforeChange).toBeCalledTimes(2);
     expect(onChange).toBeCalledTimes(1);
+
+    wrapper.unmount();
   });
 
   it('switch slot work', async () => {
@@ -99,8 +114,8 @@ describe('d-switch', () => {
       components: { DSwitch },
       template: `
         <d-switch v-model="isChecked">
-          <template v-slot:checkedContent>开</template>
-          <template v-slot:uncheckedContent>关</template>
+        <template v-slot:checkedContent>开</template>
+        <template v-slot:uncheckedContent>关</template>
         </d-switch>
       `,
       setup() {
@@ -116,6 +131,8 @@ describe('d-switch', () => {
     await nextTick();
 
     expect(wrapper.text()).toBe('开');
+
+    wrapper.unmount();
   });
 
   it('switch active-value inactive-value work', async () => {
@@ -132,13 +149,15 @@ describe('d-switch', () => {
       },
     });
 
-    expect(wrapper.classes()).toContain(baseClass);
-    expect(wrapper.classes()).toContain(checkedClass);
+    const container = wrapper.find(containerClass);
+    expect(container.classes()).toContain(checkedClass);
 
     checked.value = '关闭';
     await nextTick();
 
-    expect(wrapper.classes()).not.toContain(checkedClass);
+    expect(container.classes()).not.toContain(checkedClass);
+
+    wrapper.unmount();
   });
 
   it('switch color work', async () => {
@@ -156,21 +175,29 @@ describe('d-switch', () => {
     });
 
     expect(wrapper.classes()).toContain(baseClass);
-    expect(wrapper.classes()).not.toContain(checkedClass);
-    expect(wrapper.vm.$el.style.getPropertyValue('background-color')).not.toBe('pink');
-    expect(wrapper.vm.$el.style.getPropertyValue('border-color')).not.toBe('pink');
+    const container = wrapper.find(containerClass);
+
+    const getContainerStyle = (key: string) => {
+      return container.wrapperElement.__vnode.el.style.getPropertyValue(key);
+    };
+
+    expect(container.classes()).not.toContain(checkedClass);
+    expect(getContainerStyle('background')).not.toBe('pink');
+    expect(getContainerStyle('border-color')).not.toBe('pink');
 
     checked.value = true;
 
     await nextTick();
 
-    expect(wrapper.vm.$el.style.getPropertyValue('background-color')).toBe('pink');
-    expect(wrapper.vm.$el.style.getPropertyValue('border-color')).toBe('pink');
+    expect(getContainerStyle('background')).toBe('pink');
+    expect(getContainerStyle('border-color')).toBe('pink');
 
     await wrapper.setProps({
       color: 'green',
     });
-    expect(wrapper.vm.$el.style.getPropertyValue('background-color')).toBe('green');
-    expect(wrapper.vm.$el.style.getPropertyValue('border-color')).toBe('green');
+    expect(getContainerStyle('background')).toBe('green');
+    expect(getContainerStyle('border-color')).toBe('green');
+
+    wrapper.unmount();
   });
 });

--- a/packages/devui-vue/devui/switch/src/switch.scss
+++ b/packages/devui-vue/devui/switch/src/switch.scss
@@ -9,111 +9,123 @@
 }
 
 .#{$devui-prefix}-switch {
-  width: 36px;
-  height: 18px;
-  border-radius: $devui-border-radius-full;
-  background: $devui-line;
-  border: 1px solid $devui-line;
-  position: relative;
-  display: inline-block;
-  box-sizing: content-box;
-  overflow: visible;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  vertical-align: bottom;
-  transition: $devui-animation-duration-slow $devui-animation-ease-in-out-smooth all;
+  display: flex;
+  align-items: center;
+  width: $devui-size-md * 1.4;
+  height: $devui-size-md;
 
-  &:not(.#{$devui-prefix}-switch--checked):hover {
-    border-color: $devui-line;
-  }
-
-  &:active {
-    border-color: $devui-brand-active-focus;
-  }
-
-  &.#{$devui-prefix}-switch--checked:hover {
-    border-color: $devui-brand-active;
-  }
-
-  .#{$devui-prefix}-switch__inner-wrapper {
-    display: inline-block;
+  &__wrapper {
     width: 100%;
-    height: 100%;
-    padding-left: 16px;
-    font-size: $devui-font-size;
+    height: 62.5%;
+    border-radius: $devui-border-radius-full;
+    background: $devui-line;
+    border: 1px solid $devui-line;
+    position: relative;
+    display: inline-block;
     box-sizing: border-box;
+    overflow: visible;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    vertical-align: bottom;
+    transition: $devui-animation-duration-slow $devui-animation-ease-in-out-smooth all;
 
-    .#{$devui-prefix}-switch__inner {
-      color: $devui-light-text;
+    &:not(.#{$devui-prefix}-switch--checked):hover {
+      border-color: $devui-line;
+    }
+
+    &:active {
+      border-color: $devui-brand-active-focus;
+    }
+
+    .#{$devui-prefix}-switch__inner-wrapper {
+      display: inline-block;
       width: 100%;
       height: 100%;
-      text-align: center;
-      overflow: hidden;
+      padding-left: 14px;
+      font-size: $devui-font-size;
+      box-sizing: border-box;
+
+      .#{$devui-prefix}-switch__inner {
+        color: $devui-light-text;
+        width: 100%;
+        height: 100%;
+        text-align: center;
+        overflow: hidden;
+      }
+    }
+
+    small {
+      width: 16px;
+      height: 16px;
+      background: $devui-light-text;
+      border-radius: $devui-border-radius-full;
+      position: absolute;
+      top: 1px;
+      left: 1px;
+      transition: $devui-animation-duration-slow $devui-animation-ease-in-out-smooth all;
     }
   }
 
-  &.#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
+  // md
+  .#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
     padding-left: unset;
-    padding-right: 16px;
+    padding-right: 14px;
   }
 
-  small {
-    width: 16px;
-    height: 16px;
+  .#{$devui-prefix}-switch--checked small {
     background: $devui-light-text;
-    border-radius: $devui-border-radius-full;
-    position: absolute;
-    top: 1px;
-    left: 1px;
-    transition: $devui-animation-duration-slow $devui-animation-ease-in-out-smooth all;
+    left: 26px;
   }
 
-  &.#{$devui-prefix}-switch--checked small {
-    left: 19px;
-  }
+  // lg
+  &--lg {
+    width: $devui-size-lg * 1.4;
+    height: $devui-size-lg;
 
-  &.#{$devui-prefix}-switch--lg {
-    width: 58px;
-    height: 28px;
+    .#{$devui-prefix}-switch__wrapper {
+      height: 64%;
+    }
 
     .#{$devui-prefix}-switch__inner-wrapper {
-      padding-left: 28px;
-      padding-top: 2px;
+      padding-left: 24px;
       font-size: $devui-font-size-modal-title;
     }
 
-    &.#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
+    .#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
       padding-left: unset;
-      padding-right: 28px;
+      padding-right: 24px;
     }
 
     & small {
-      width: 26px;
-      height: 26px;
-      top: 1px;
-      left: 1px;
+      width: 22px;
+      height: 22px;
     }
 
-    &.#{$devui-prefix}-switch--checked small {
+    .#{$devui-prefix}-switch--checked small {
       background: $devui-light-text;
-      left: 30px;
+      left: 31px;
     }
   }
 
-  &.#{$devui-prefix}-switch--sm {
-    width: 30px;
-    height: 15px;
+  // sm
+  &--sm {
+    width: $devui-size-sm * 1.4;
+    height: $devui-size-sm;
 
-    .#{$devui-prefix}-switch__inner-wrapper {
-      padding-left: 12px;
-      font-size: $devui-font-size-sm;
-      vertical-align: top;
+    .#{$devui-prefix}-switch__wrapper {
+      height: 66%;
     }
 
-    &.#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
+    .#{$devui-prefix}-switch__inner-wrapper {
+      line-height: 1;
+      padding-left: 12px;
+      font-size: $devui-font-size-sm;
+    }
+
+    .#{$devui-prefix}-switch--checked .#{$devui-prefix}-switch__inner-wrapper {
       padding-left: unset;
-      padding-right: 12px;
+      padding-right: 18px;
     }
 
     & small {
@@ -122,12 +134,12 @@
       position: absolute;
     }
 
-    &.#{$devui-prefix}-switch--checked small {
-      left: 17px;
+    .#{$devui-prefix}-switch--checked small {
+      left: 19px;
     }
   }
 
-  &.#{$devui-prefix}-switch--checked {
+  &--checked {
     background: $devui-brand;
     border-color: $devui-brand;
 
@@ -142,7 +154,7 @@
     }
   }
 
-  &.#{$devui-prefix}-switch--disabled {
+  &--disabled {
     &,
     &:hover,
     &:active,

--- a/packages/devui-vue/devui/switch/src/switch.tsx
+++ b/packages/devui-vue/devui/switch/src/switch.tsx
@@ -12,26 +12,34 @@ export default defineComponent({
     const ns = useNamespace('switch');
     const { toggle, checked, switchDisabled, switchSize } = useSwitch(props, ctx);
     return () => {
-      const outerCls = {
+      const switchCls = {
         [ns.b()]: true,
         [ns.m(switchSize.value)]: true,
+      };
+
+      const switchWrapperCls = {
+        [ns.e('wrapper')]: true,
         [ns.m('checked')]: checked.value,
         [ns.m('disabled')]: switchDisabled.value,
       };
-      const outerStyle = [
+
+      const switchWrapperStyle = [
         `background: ${checked.value && !switchDisabled.value ? props.color : ''}`,
         `border-color: ${checked.value && !switchDisabled.value ? props.color : ''}`,
       ];
 
       const checkedContent = renderSlot(useSlots(), 'checkedContent');
       const uncheckedContent = renderSlot(useSlots(), 'uncheckedContent');
+
       return (
-        <span class={outerCls} style={outerStyle} onClick={toggle}>
-          <span class={ns.e('inner-wrapper')}>
-            <div class={ns.e('inner')}>{checked.value ? checkedContent : uncheckedContent}</div>
+        <div class={switchCls}>
+          <span class={switchWrapperCls} style={switchWrapperStyle} onClick={toggle}>
+            <span class={ns.e('inner-wrapper')}>
+              <div class={ns.e('inner')}>{checked.value ? checkedContent : uncheckedContent}</div>
+            </span>
+            <small></small>
           </span>
-          <small></small>
-        </span>
+        </div>
       );
     };
   },

--- a/packages/devui-vue/docs/components/switch/index.md
+++ b/packages/devui-vue/docs/components/switch/index.md
@@ -6,14 +6,14 @@
 
 当两种状态需要来回切换控制时，比如启用/禁用。
 
-### size
+### 尺寸
 
-:::demo size 可选：`sm | md | lg`，默认为`md`
+:::demo 可选，`sm | md | lg`，默认为`md`。
 
 ```vue
 <template>
-  <d-switch class="mr-1" v-model="checkedSmall" size="sm"></d-switch>
-  <d-switch class="mr-1" v-model="uncheckedMiddle"></d-switch>
+  <d-switch v-model="checkedSmall" size="sm"></d-switch>
+  <d-switch v-model="uncheckedMiddle"></d-switch>
   <d-switch v-model="checkedLarge" size="lg"></d-switch>
 </template>
 <script>
@@ -22,7 +22,7 @@ import { defineComponent, ref } from 'vue';
 export default defineComponent({
   setup() {
     const checkedSmall = ref(true);
-    const uncheckedMiddle = ref(false);
+    const uncheckedMiddle = ref(true);
     const checkedLarge = ref(true);
     return {
       checkedSmall,
@@ -42,9 +42,9 @@ export default defineComponent({
 
 :::
 
-### disabled
+### 禁用
 
-:::demo 可选，是否禁用开关，默认为 false
+:::demo 可选，是否禁用开关，默认为 false。
 
 ```vue
 <template>
@@ -75,9 +75,9 @@ export default defineComponent({
 
 ```vue
 <template>
-  <div style="display: flex;">
-    <d-switch class="mr-1" v-model="checkedColor" color="#FECC55"></d-switch>
-    <d-switch class="mr-1" color="#50D4AB" v-model="checkedIcon">
+  <div>
+    <d-switch v-model="checkedColor" color="#FECC55"></d-switch>
+    <d-switch color="#50D4AB" v-model="checkedIcon">
       <template #checkedContent>
         <i class="icon-right"></i>
       </template>
@@ -156,14 +156,14 @@ export default defineComponent({
 
 ### Switch 参数
 
-| 参数           | 类型                        | 默认  | 说明                         | 跳转 Demo                     |
-| :------------- | :-------------------------- | :---- | :--------------------------- | :---------------------------- |
-| v-model        | `string\| number \|boolean` | --    | 绑定值                       | [基本用法](#size)             |
-| size           | `sm \| md \| lg`            | `md`  | 可选，开关尺寸大小           | [size](#size)                 |
+| 参数           | 类型                          | 默认  | 说明                         | 跳转 Demo                     |
+| :------------- |:----------------------------| :---- | :--------------------------- | :---------------------------- |
+| v-model        | `string\                    | number \|boolean` | --    | 绑定值                       | [基本用法](#size)             |
+| size           | [ISwitchSize](#iswitchsize) | `md`  | 可选，开关尺寸大小           | [size](#size)                 |
 | color          | `string`                    | --    | 可选，开关打开时的自定义颜色 | [自定义样式](#自定义样式)     |
 | disabled       | `boolean`                   | false | 可选，是否禁用开关           | [基本用法](#size)             |
-| active-value   | `string\| number \|boolean` | true  | 可选，开关打开时的值         | [自定义绑定值](#自定义绑定值) |
-| inactive-value | `string\| number \|boolean` | true  | 可选，开关关闭时的值         | [自定义绑定值](#自定义绑定值) |
+| active-value   | `string\                    | number \|boolean` | true  | 可选，开关打开时的值         | [自定义绑定值](#自定义绑定值) |
+| inactive-value | `string\                    | number \|boolean` | true  | 可选，开关关闭时的值         | [自定义绑定值](#自定义绑定值) |
 
 ### Switch 事件
 
@@ -177,3 +177,9 @@ export default defineComponent({
 | :--------------- | :------------- | :--- | :------------------------ |
 | checkedContent   | 打开状态的文案 | --   | [自定义样式](#自定义样式) |
 | uncheckedContent | 关闭状态的文案 | --   | [自定义样式](#自定义样式) |
+
+### Switch 类型定义
+#### ISwitchSize
+```ts
+type ISwitchSize = 'sm' | 'md' | 'lg';
+```


### PR DESCRIPTION
1. switch 组件大小向标准统一
2. 修复更改的测试错误，主要原因是加了一层容器
3. 优化组件文档（二级标题改为中文）