### PR TITLE
修复 Radio 组件 size 属性的逻辑 （#1199）

### DIFF
--- a/packages/devui-vue/devui/radio/__tests__/radio-group.spec.ts
+++ b/packages/devui-vue/devui/radio/__tests__/radio-group.spec.ts
@@ -168,7 +168,7 @@ describe('RadioGroup', () => {
 
     const radio1 = wrapper.findAllComponents({ name: 'DRadio' })[0];
     const radio1Wrapper = radio1.find(radioBaseClass);
-    expect(radio1Wrapper.classes()).not.toContain(sizeNs);
+    expect(radio1Wrapper.classes()).toContain(sizeNs);
     await wrapper.setProps({
       border: true,
     });

--- a/packages/devui-vue/devui/radio/__tests__/radio.spec.ts
+++ b/packages/devui-vue/devui/radio/__tests__/radio.spec.ts
@@ -119,7 +119,7 @@ describe('Radio', () => {
       },
     });
     const container = wrapper.find(baseClass);
-    expect(container.classes()).not.toContain(sizeNs);
+    expect(container.classes()).toContain(sizeNs);
     await wrapper.setProps({
       border: true,
     });

--- a/packages/devui-vue/devui/radio/src/radio-types.ts
+++ b/packages/devui-vue/devui/radio/src/radio-types.ts
@@ -25,8 +25,7 @@ const radioCommonProps = {
     default: false,
   },
   size: {
-    type: String as PropType<sizeTypes>,
-    default: 'md',
+    type: String as PropType<sizeTypes>
   },
 };
 

--- a/packages/devui-vue/devui/radio/src/radio.tsx
+++ b/packages/devui-vue/devui/radio/src/radio.tsx
@@ -20,7 +20,7 @@ export default defineComponent({
         disabled: isDisabled.value,
         [ns.b()]: true,
         [ns.m('bordered')]: border.value,
-        [ns.m(size.value)]: border.value,
+        [ns.m(size.value)]: size.value,
       };
 
       return (

--- a/packages/devui-vue/devui/radio/src/use-radio.ts
+++ b/packages/devui-vue/devui/radio/src/use-radio.ts
@@ -60,8 +60,9 @@ export function useRadio(props: RadioProps, ctx: SetupContext): UseRadioFn {
   });
 
   const size = computed(() => {
-    return formContext?.size || radioGroupConf?.size.value || props.size;
+    return props.size || radioGroupConf?.size.value || formContext?.size || 'md';
   });
+
   watch(
     () => props.modelValue,
     () => {
@@ -79,7 +80,9 @@ export function useRadio(props: RadioProps, ctx: SetupContext): UseRadioFn {
 }
 
 export function useRadioGroup(props: RadioGroupProps, ctx: SetupContext): void {
+  const formContext = inject(FORM_TOKEN, undefined);
   const formItemContext = inject(FORM_ITEM_TOKEN, undefined);
+
   /** change 事件 */
   const emitChange = (radioValue: valueTypes) => {
     ctx.emit('update:modelValue', radioValue);
@@ -93,13 +96,16 @@ export function useRadioGroup(props: RadioGroupProps, ctx: SetupContext): void {
     }
   );
 
+  // 组件 size 优先于表单 size
+  const radioGroupSize = computed(() => props.size || formContext?.size || '');
+
   // 注入给子组件
   provide(radioGroupInjectionKey, {
     modelValue: toRef(props, 'modelValue'),
     name: toRef(props, 'name'),
     disabled: toRef(props, 'disabled'),
     border: toRef(props, 'border'),
-    size: toRef(props, 'size'),
+    size: radioGroupSize,
     beforeChange: props.beforeChange,
     emitChange,
     fill: toRef(props, 'fill'),


### PR DESCRIPTION
1. 组件的 size > 表单的 size > 默认大小 md
2. 测试中组件设置了 size 属性，元素应该包含相关 class 类名