### PR TITLE
修复 checkbox 组件 size 属性的逻辑 （#1199）

### DIFF
--- a/packages/devui-vue/devui/checkbox/__tests__/checkbox-button.spec.ts
+++ b/packages/devui-vue/devui/checkbox/__tests__/checkbox-button.spec.ts
@@ -30,6 +30,8 @@ describe('checkbox-button', () => {
 
     expect(container.classes()).not.toContain('active');
     expect(container.classes()).toContain('unchecked');
+
+    wrapper.unmount();
   });
 
   it('checkbox-button title work', async () => {
@@ -54,6 +56,8 @@ describe('checkbox-button', () => {
       isShowTitle: false,
     });
     expect(label.attributes('title')).toEqual('');
+
+    wrapper.unmount();
   });
 
   it('checkbox-button disabled work', async () => {
@@ -77,6 +81,8 @@ describe('checkbox-button', () => {
     await label.trigger('click');
     expect(wrapper.find(baseClass).classes()).not.toContain('disabled');
     expect(onChange).toBeCalledTimes(1);
+
+    wrapper.unmount();
   });
 
   it('checkbox-button beforeChange work', async () => {
@@ -113,6 +119,8 @@ describe('checkbox-button', () => {
     expect(beforeChange).toBeCalledTimes(2);
     expect(onChange).toBeCalledTimes(1);
     expect(checked.value).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox-button size work', async () => {
@@ -124,5 +132,7 @@ describe('checkbox-button', () => {
     });
 
     expect(wrapper.find(sizeLgClass).exists()).toBe(true);
+
+    wrapper.unmount();
   });
 });

--- a/packages/devui-vue/devui/checkbox/__tests__/checkbox-group.spec.ts
+++ b/packages/devui-vue/devui/checkbox/__tests__/checkbox-group.spec.ts
@@ -48,6 +48,8 @@ describe('d-checkbox-group', () => {
     await nextTick();
     expect(box1.classes()).toContain('active');
     expect(box2.classes()).toContain('unchecked');
+
+    wrapper.unmount();
   });
 
   it('checkbox-group disabled work', async () => {
@@ -86,6 +88,8 @@ describe('d-checkbox-group', () => {
     expect(list.value).toStrictEqual(['b', 'a']);
     expect(onChange).toBeCalledTimes(1);
     expect(wrapper.findAll(baseClass).some((el) => el.classes().includes('disabled'))).toBe(false);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group direction work', async () => {
@@ -116,6 +120,8 @@ describe('d-checkbox-group', () => {
     direction.value = 'row';
     await nextTick();
     expect(wrapper.find('.is-row').exists()).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group itemWidth work', () => {
@@ -141,6 +147,8 @@ describe('d-checkbox-group', () => {
     });
 
     expect(wrapper.findAll(wrapClass).length).toBe(2);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group options work', () => {
@@ -174,6 +182,8 @@ describe('d-checkbox-group', () => {
     expect(boxList.length).toBe(2);
     expect(boxList[0].classes()).toContain('unchecked');
     expect(boxList[1].classes()).toContain('active');
+
+    wrapper.unmount();
   });
 
   it('checkbox-group beforeChange work', async () => {
@@ -213,6 +223,8 @@ describe('d-checkbox-group', () => {
     expect(beforeChange).toHaveBeenCalledTimes(2);
     expect(onChange).toBeCalledTimes(1);
     expect(list.value).toStrictEqual(['b', 'a']);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group max work', async () => {
@@ -250,6 +262,8 @@ describe('d-checkbox-group', () => {
     await label2.trigger('click');
     expect(list.value).toStrictEqual(['c']);
     expect(wrapper.findAll(baseClass).filter((el) => el.classes().includes('disabled'))?.length).toBe(0);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group border size work', () => {
@@ -274,6 +288,8 @@ describe('d-checkbox-group', () => {
 
     expect(wrapper.find(borderClass).exists()).toBe(true);
     expect(wrapper.find(sizeLgClass).exists()).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox-group checkbox-button', async () => {
@@ -302,6 +318,8 @@ describe('d-checkbox-group', () => {
     expect(list.value).toStrictEqual(['b', 'a']);
     await label2.trigger('click');
     expect(list.value).toStrictEqual(['a']);
+
+    wrapper.unmount();
   });
 
   it('checkbox-button color text-color', async () => {
@@ -327,5 +345,7 @@ describe('d-checkbox-group', () => {
     await nextTick();
     const content = wrapper.findAll(contentClass);
     expect(content[0].attributes().style).toBe('border-color: red; background-color: red; color: rgb(204, 204, 204);');
+
+    wrapper.unmount();
   });
 });

--- a/packages/devui-vue/devui/checkbox/__tests__/checkbox.spec.ts
+++ b/packages/devui-vue/devui/checkbox/__tests__/checkbox.spec.ts
@@ -34,6 +34,8 @@ describe('checkbox', () => {
 
     expect(container.classes()).not.toContain('active');
     expect(container.classes()).toContain('unchecked');
+
+    wrapper.unmount();
   });
 
   it('checkbox title work', async () => {
@@ -58,6 +60,8 @@ describe('checkbox', () => {
       isShowTitle: false,
     });
     expect(label.attributes('title')).toEqual('');
+
+    wrapper.unmount();
   });
 
   it('checkbox showAnimation work', async () => {
@@ -73,6 +77,8 @@ describe('checkbox', () => {
       showAnimation: false,
     });
     expect(wrapper.findAll(noAnimationClass).length).toBe(2);
+
+    wrapper.unmount();
   });
 
   it('checkbox disabled work', async () => {
@@ -96,6 +102,8 @@ describe('checkbox', () => {
     await label.trigger('click');
     expect(wrapper.find(baseClass).classes()).not.toContain('disabled');
     expect(onChange).toBeCalledTimes(1);
+
+    wrapper.unmount();
   });
 
   it('checkbox halfchecked work', async () => {
@@ -115,6 +123,8 @@ describe('checkbox', () => {
     });
     expect(container.classes()).toContain('half-checked');
     expect(container.find(defaultBgClass).exists()).toBe(false);
+
+    wrapper.unmount();
   });
 
   it('checkbox beforeChange work', async () => {
@@ -151,6 +161,8 @@ describe('checkbox', () => {
     expect(beforeChange).toBeCalledTimes(2);
     expect(onChange).toBeCalledTimes(1);
     expect(checked.value).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox border work', async () => {
@@ -167,6 +179,8 @@ describe('checkbox', () => {
       border: true,
     });
     expect(wrapper.find(borderClass).exists()).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox size work', async () => {
@@ -178,12 +192,14 @@ describe('checkbox', () => {
       },
     });
 
-    expect(wrapper.find(sizeLgClass).exists()).toBe(false);
+    expect(wrapper.find(sizeLgClass).exists()).toBe(true);
 
     await wrapper.setProps({
       border: true,
     });
-    expect(wrapper.find(sizeLgClass).exists()).toBe(true);
+    expect(wrapper.find(borderClass).exists()).toBe(true);
+
+    wrapper.unmount();
   });
 
   it('checkbox color work', async () => {
@@ -224,5 +240,7 @@ describe('checkbox', () => {
     // 找不到backgroundImage属性
     // expect(element.style.backgroundImage).toBe('linear-gradient(pink, pink)'); // can't find backgroundImage
     expect(element.style.backgroundColor).toBe('pink');
+
+    wrapper.unmount();
   });
 });

--- a/packages/devui-vue/devui/checkbox/src/checkbox-types.ts
+++ b/packages/devui-vue/devui/checkbox/src/checkbox-types.ts
@@ -36,8 +36,7 @@ const commonProps = {
     default: undefined,
   },
   size: {
-    type: String as PropType<Size>,
-    default: 'md',
+    type: String as PropType<Size>
   },
 } as const;
 
@@ -147,7 +146,7 @@ export type UseCheckboxFn = {
   direction: string | undefined;
   size: ComputedRef<string>;
   border: ComputedRef<boolean>;
-  handleClick: () => void;
+  handleClick: (event: Event) => void;
 };
 
 export interface GroupDefaultOpt {

--- a/packages/devui-vue/devui/checkbox/src/checkbox.tsx
+++ b/packages/devui-vue/devui/checkbox/src/checkbox.tsx
@@ -22,6 +22,7 @@ export default defineComponent({
       size,
       border,
     } = useCheckbox(props, ctx);
+
     return () => {
       const wrapperCls = {
         [ns.e('column-margin')]: direction === 'column',
@@ -55,7 +56,7 @@ export default defineComponent({
         [ns.m('no-animation')]: !mergedShowAnimation.value,
       };
       const labelCls = {
-        [ns.m(size.value)]: border.value,
+        [ns.m(size.value)]: size.value,
         [ns.m('bordered')]: border.value,
       };
       const stopPropagation = ($event: Event) => $event.stopPropagation();

--- a/packages/devui-vue/devui/checkbox/src/use-checkbox.ts
+++ b/packages/devui-vue/devui/checkbox/src/use-checkbox.ts
@@ -64,8 +64,11 @@ export function useCheckbox(props: CheckboxProps, ctx: SetupContext): UseCheckbo
     $event.stopPropagation();
     canChange(!isChecked.value, props.label).then((res) => res && toggle());
   };
-  const size = computed(() => formContext?.size || checkboxGroupConf?.size.value || props.size);
+
+  const size = computed(() => props.size || checkboxGroupConf?.size.value || formContext?.size || 'md');
+
   const border = computed(() => checkboxGroupConf?.border.value ?? props.border);
+
   watch(
     () => props.modelValue,
     () => {
@@ -89,6 +92,7 @@ export function useCheckbox(props: CheckboxProps, ctx: SetupContext): UseCheckbo
 type IModelValue = Ref<(string | number | { value: string })[]>;
 
 export function useCheckboxGroup(props: CheckboxGroupProps, ctx: SetupContext): UseCheckboxGroupFn {
+  const formContext = inject(FORM_TOKEN, undefined);
   const formItemContext = inject(FORM_ITEM_TOKEN, undefined);
   const valList = toRef(props, 'modelValue') as IModelValue;
 
@@ -139,6 +143,9 @@ export function useCheckboxGroup(props: CheckboxGroupProps, ctx: SetupContext): 
     { deep: true }
   );
 
+  // 组件 size 优先于表单 size
+  const checkboxGroupSize = computed(() => props.size || formContext?.size || '');
+
   provide(checkboxGroupInjectionKey, {
     disabled: toRef(props, 'disabled'),
     isShowTitle: toRef(props, 'isShowTitle'),
@@ -149,7 +156,7 @@ export function useCheckboxGroup(props: CheckboxGroupProps, ctx: SetupContext): 
     toggleGroupVal,
     itemWidth: toRef(props, 'itemWidth'),
     direction: toRef(props, 'direction'),
-    size: toRef(props, 'size'),
+    size: checkboxGroupSize,
     border: toRef(props, 'border'),
     max: toRef(props, 'max'),
     modelValue: toRef(props, 'modelValue'),


### PR DESCRIPTION
1. 组件的 size > 表单的 size > 默认大小 md
2. 更改后的测试错误， 测试用例增加 wrapper.unmount()