### PR TITLE
fix(modal): 修复弹窗组件信息提示图标的颜色

### DIFF
--- a/packages/devui-vue/devui/modal/src/modal.tsx
+++ b/packages/devui-vue/devui/modal/src/modal.tsx
@@ -13,6 +13,7 @@ interface TypeList {
   type: ModalType;
   text: string;
   icon: string;
+  color: string;
 }
 
 export default defineComponent({
@@ -42,21 +43,25 @@ export default defineComponent({
           type: 'success',
           text: '成功',
           icon: 'right-o',
+          color: 'var(--devui-success)',
         },
         {
           type: 'failed',
           text: '错误',
           icon: 'error-o',
+          color: 'var(--devui-danger)',
         },
         {
           type: 'warning',
           text: '警告',
           icon: 'warning-o',
+          color: 'var(--devui-warning)',
         },
         {
           type: 'info',
           text: '信息',
           icon: 'info-o',
+          color: 'var(--devui-info)',
         },
       ];
       const item = typeList.find((i) => i.type === props.type);
@@ -65,7 +70,7 @@ export default defineComponent({
           <DModalHeader>
             <div class="type-content">
               <div class="type-content-icon">
-                <Icon name={item?.icon}></Icon>
+                <Icon name={item?.icon} color={item?.color}></Icon>
               </div>
               <div class="type-content-text">{item?.text}</div>
             </div>


### PR DESCRIPTION
给不同类型弹窗的图标添加颜色
![1671526666002](https://user-images.githubusercontent.com/63504321/208625890-72a70341-23e4-4434-9ca3-42e82d5ec94e.png)
