### PR TITLE
fix(ImagePreview): 修复图片拖动并重置，再次拖动时的位置问题

### DIFF
--- a/packages/devui-vue/devui/image-preview/src/transform.ts
+++ b/packages/devui-vue/devui/image-preview/src/transform.ts
@@ -122,6 +122,8 @@ export default class Transform {
   reset(): void {
     this.transformX = this.TRANSFORMX;
     this.transformY = this.TRANSFORMY;
+    this.oTransformX = this.transformX;
+    this.oTransformY = this.transformY;
     this.zoom = this.ZOOM;
   }
   setPosition(): void {


### PR DESCRIPTION
https://vue-devui.github.io/components/image-preview/
问题：
图片预览时，拖动图片后通过ZoomBest/ZoomOriginal重置图片后，再次拖动，图片会回到重置前的位置。