### PR TITLE
feat: 1524 组件demo中，点击复制代码片段之后，文字消失问题解决

### DIFF
--- a/packages/devui-vue/docs/.vitepress/config/lang.ts
+++ b/packages/devui-vue/docs/.vitepress/config/lang.ts
@@ -2,13 +2,15 @@ const lang = {
   '/': {
     'hide-text': '隐藏代码',
     'show-text': '显示代码',
-    'copy-button-text': '复制代码片段'
+    'copy-button-text': '复制代码片段',
+    'copy-success-text': '复制成功',
   },
   '/en-US': {
     'hide-text': 'Hide',
     'show-text': 'Expand',
-    'copy-button-text': 'Copy'
-  }
-}
+    'copy-button-text': 'Copy',
+    'copy-success-text': 'Copy Success',
+  },
+};
 
-export default lang
+export default lang;


### PR DESCRIPTION
lang.ts文件中缺失复制成文本字段，代码里先使用配置文件中的文本导致Demo.vue配置的缺省值没有作用