### PR TITLE
chore(site): add current version number to the top nav bar

### DIFF
--- a/packages/devui-vue/docs/.vitepress/config/nav.ts
+++ b/packages/devui-vue/docs/.vitepress/config/nav.ts
@@ -1,7 +1,10 @@
+import { version } from '../../../package.json';
+
 const nav = [
   { text: '组件', link: '/quick-start/' },
   { text: '贡献指南', link: '/contributing/' },
   { text: 'Playground', link: 'https://devcloudfe.github.io/devui-playground' },
+  { text: version, link: `https://github.com/DevCloudFE/vue-devui/releases/tag/v${version}` },
   {
     text: '文档',
     items: [
@@ -20,6 +23,6 @@ const nav = [
       { text: '图标库', link: 'https://devui.design/icon/ruleResource' },
     ],
   },
-]
+];
 
-export default nav
+export default nav;


### PR DESCRIPTION
The display effect is as follows:

<img width="551" alt="image" src="https://user-images.githubusercontent.com/9566362/212461614-0a0ceafe-8c75-4a04-86eb-22cc3d210545.png">

