### PR TITLE
docs(layout): 修复 layout 文档示例未正确展示 logo 的bug(#112)。

### DIFF
--- a/packages/devui-vue/docs/components/layout/index.md
+++ b/packages/devui-vue/docs/components/layout/index.md
@@ -11,6 +11,7 @@
 ::: demo
 
 ```vue
+
 <template>
   <d-layout>
     <d-header class="dheader">Header</d-header>
@@ -20,17 +21,18 @@
 </template>
 
 <style>
-    .dheader, .dfooter {
-        background: #333854;
-        color: #fff;
-        text-align: center;
-        line-height: 40px;
-    }
-    .dcontent {
-        height: 200px;
-        line-height: 200px;
-        text-align: center;
-    }
+.dheader, .dfooter {
+  background: #333854;
+  color: #fff;
+  text-align: center;
+  line-height: 40px;
+}
+
+.dcontent {
+  height: 200px;
+  line-height: 200px;
+  text-align: center;
+}
 </style>
 ```
 
@@ -39,6 +41,7 @@
 :::demo
 
 ```vue
+
 <template>
   <d-layout>
     <d-header class="dheader">Header</d-header>
@@ -51,28 +54,30 @@
 </template>
 
 <style>
-    .dheader, .dfooter {
-        background: #333854;
-        color: #fff;
-        text-align: center;
-        line-height: 40px;
-    }
-    .daside {
-        background: #f8f8f8;
-        width: 100px;
-        min-height: 200px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
+.dheader, .dfooter {
+  background: #333854;
+  color: #fff;
+  text-align: center;
+  line-height: 40px;
+}
+
+.daside {
+  background: #f8f8f8;
+  width: 100px;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 </style>
 ```
 
-::: 
+:::
 
 :::demo
 
 ```vue
+
 <template>
   <d-layout>
     <d-header class="dheader">Header</d-header>
@@ -85,20 +90,21 @@
 </template>
 
 <style>
-    .dheader, .dfooter {
-        background: #333854;
-        color: #fff;
-        text-align: center;
-        line-height: 40px;
-    }
+.dheader, .dfooter {
+  background: #333854;
+  color: #fff;
+  text-align: center;
+  line-height: 40px;
+}
 </style>
 ```
 
-::: 
+:::
 
 :::demo
 
 ```vue
+
 <template>
   <d-layout>
     <d-aside class="daside">Aside</d-aside>
@@ -111,29 +117,31 @@
 </template>
 
 <style>
-    .daside {
-        background: #f8f8f8;
-        width: 100px;
-        min-height: 200px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .dheader, .dfooter {
-        background: #333854;
-        color: #fff;
-        text-align: center;
-        line-height: 40px;
-        min-height: 40px;
-    }
-    .main-content {
-        line-height: 200px;
-        text-align: center;
-    }
+.daside {
+  background: #f8f8f8;
+  width: 100px;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dheader, .dfooter {
+  background: #333854;
+  color: #fff;
+  text-align: center;
+  line-height: 40px;
+  min-height: 40px;
+}
+
+.main-content {
+  line-height: 200px;
+  text-align: center;
+}
 </style>
 ```
 
-::: 
+:::
 
 ### 应用场景1
 
@@ -142,77 +150,78 @@
 :::demo
 
 ```vue
+
 <template>
-    <d-layout>
-        <d-header class="dheader-1">
-            <div class="logo">
-                <span class="logo-devui">
-                    <img src="https://devui.design/components/assets/logo.svg" width="26" height="26" />
-                </span>
-                <span class="text">DevUI</span>
-            </div>
-        </d-header>
-        <d-content class="dcontent-1">
-            <d-breadcrumb class="dbreadcrumb">
-                <d-breadcrumb-item>
-                    <span>DevUI</span>
-                </d-breadcrumb-item>
-                <d-breadcrumb-item>
-                    <span>面包屑</span>
-                </d-breadcrumb-item>
-            </d-breadcrumb>
-            <div class="inner-content"></div>
-        </d-content>
-        <d-footer class="dfooter-1">footer</d-footer>
-    </d-layout>
+  <d-layout>
+    <d-header class="dheader-1">
+      <img class="logo-devui" src="https://devui.design/components/assets/logo.svg" alt="" />
+      <span class="text">DevUI</span>
+    </d-header>
+    <d-content class="dcontent-1">
+      <d-breadcrumb class="dbreadcrumb">
+        <d-breadcrumb-item>
+          <span>DevUI</span>
+        </d-breadcrumb-item>
+        <d-breadcrumb-item>
+          <span>面包屑</span>
+        </d-breadcrumb-item>
+      </d-breadcrumb>
+      <div class="inner-content"></div>
+    </d-content>
+    <d-footer class="dfooter-1">footer</d-footer>
+  </d-layout>
 </template>
 
-<style>
-    .dheader-1 {
-        text-align: left;
-        position: relative;
-        height: 40px;
-        background-color: #333854;
-        color: #fff;
-    }
-    .dheader-1 .logo {
-        position: absolute;
-        left: 0;
-        margin-left: 40px;
-        height: 40px;
-        width: 120px;
-        color: #fff;
-        font-size: 16px;
-        line-height: 40px;
-    }
-    .dheader-1 .logo .logo-devui {
-        margin-top: 8px;
-    }
+<style lang="scss" scoped>
+.dheader-1 {
+  text-align: left;
+  position: relative;
+  height: 40px;
+  background-color: #333854;
+  color: #fff;
+}
 
-    .dheader-1 .logo .logo-devui,
-    .dheader-1 .logo .text {
-        display: inline-block;
-        vertical-align: top;
-    }
-    .dcontent-1 {
-        padding: 0 40px;
-        height: 300px;
-        background-color: #f3f6f8;
-    }
-    .dcontent-1 .dbreadcrumb {
-        margin: 8px 0;
-    }
-    .dcontent-1 .inner-content {
-        background-color: #fff;
-        height: 100%;
-    }
-    .dfooter-1 {
-        background: #333854;
-        color: #fff;
-        text-align: center;
-        line-height: 40px;
-        min-height: 40px;
-    }
+.dheader-1 {
+  position: relative;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  background-color: #333854;
+
+  .logo-devui {
+    width: 26px;
+    height: 26px;
+    margin: 0 10px;
+  }
+
+  .text {
+    color: #fff;
+    font-size: 16px;
+  }
+}
+
+.dcontent-1 {
+  padding: 0 40px;
+  height: 300px;
+  background-color: #f3f6f8;
+
+  .dbreadcrumb {
+    margin: 8px 0;
+  }
+
+  .inner-content {
+    background-color: #fff;
+    height: 100%;
+  }
+}
+
+.dfooter-1 {
+  background: #333854;
+  color: #fff;
+  text-align: center;
+  line-height: 40px;
+  min-height: 40px;
+}
 </style>
 
 ```
@@ -226,128 +235,110 @@
 :::demo
 
 ```vue
+
 <template>
-    <d-layout class="dlayout-2">
-        <d-header class="dheader-2">
-            <div class="logo">
-            <span class="logo-devui">
-                <img src="https://devui.design/components/assets/logo.svg" width="26px" height="26px" />
-            </span>
-            <span class="text">DevUI</span>
-            </div>
-        </d-header>
-        <d-layout>
-            <d-aside class="daside-2">
-                <d-accordion :data="menu" class="menu"></d-accordion>
-            </d-aside>
-            <d-content class="dcontent-2">
-                <d-breadcrumb class="dbreadcrumb">
-                    <d-breadcrumb-item>
-                        <span>DevUI</span>
-                    </d-breadcrumb-item>
-                    <d-breadcrumb-item>
-                        <span>面包屑</span>
-                    </d-breadcrumb-item>
-                </d-breadcrumb>
-                <div class="inner-content"></div>
-            </d-content>
-        </d-layout>
-        <d-footer class="dfooter-2">footer</d-footer>
+  <d-layout>
+    <d-header class="dheader-2">
+      <img class="logo-devui" src="https://devui.design/components/assets/logo.svg" alt="" />
+      <span class="text">DevUI</span>
+    </d-header>
+    <d-layout>
+      <d-aside class="daside-2">
+        <d-accordion :data="menu" class="menu"></d-accordion>
+      </d-aside>
+      <d-content class="dcontent-2">
+        <d-breadcrumb class="dbreadcrumb">
+          <d-breadcrumb-item>
+            <span>DevUI</span>
+          </d-breadcrumb-item>
+          <d-breadcrumb-item>
+            <span>面包屑</span>
+          </d-breadcrumb-item>
+        </d-breadcrumb>
+        <div class="inner-content"></div>
+      </d-content>
     </d-layout>
+    <d-footer class="dfooter-2">footer</d-footer>
+  </d-layout>
 </template>
 
 <script>
 import { defineComponent, ref } from 'vue'
 
 export default defineComponent({
-    setup() {
-        const menu = ref([
-            {
-                title: '内容一',
-                open: true,
-                children: [{ title: '子内容1' }, { title: '子内容2' }, { title: '子内容3' }],
-            },
-            {
-                title: '内容二',
-                children: [{ title: '子内容1' }, { title: '子内容2' }, { title: '子内容3' }],
-            },
-            {
-                title: '内容三（默认展开）',
-                open: true,
-                children: [{ title: '子内容1(禁用)', disabled: true }, { title: '子内容2(默认激活)', active: true }, { title: '子内容3' }],
-            },
-        ])
-        return {
-            menu
-        }
+  setup() {
+    const menu = ref([
+      {
+        title: '内容一',
+        open: true,
+        children: [{ title: '子内容1' }, { title: '子内容2' }, { title: '子内容3' }],
+      },
+      {
+        title: '内容二',
+        children: [{ title: '子内容1' }, { title: '子内容2' }, { title: '子内容3' }],
+      },
+      {
+        title: '内容三（默认展开）',
+        open: true,
+        children: [{ title: '子内容1(禁用)', disabled: true }, {
+          title: '子内容2(默认激活)',
+          active: true
+        }, { title: '子内容3' }],
+      },
+    ])
+    return {
+      menu
     }
+  }
 })
 
 </script>
 
-<style>
-    .dlayout-2 {
-        background-color: #fff;
-    }
-    .dlayout-2 li {
-        list-style: none;
-    }
+<style lang="scss" scoped>
+.daside-2 {
+  border-left: 1px solid transparent;
+}
 
-    .daside-2 {
-        border-left: 1px solid transparent;
-    }
+.dheader-2 {
+  position: relative;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  background-color: #333854;
 
-    .dheader-2 {
-        text-align: left;
-        height: 40px;
-        background-color: #333854;
-        position: relative;
-        
-    }
-    .dheader-2 .search {
-        color: #fff;
-        margin-right: 40px;
-        position: absolute;
-        right: 0;
-    }
+  .logo-devui {
+    width: 26px;
+    height: 26px;
+    margin: 0 10px;
+  }
 
-    .dheader-2 .logo {
-        position: absolute;
-        left: 0;
-        margin-left: 20px;
-        height: 40px;
-        width: 120px;
-        color: #fff;
-        font-size: 16px;
-        line-height: 40px;
-    }
-    .dheader-2 .logo .logo-devui {
-        margin-top: 8px;
-    }
-    .dheader-2 .logo .logo-devui,
-    .dheader-2 .logo .text {
-        display: inline-block;
-        vertical-align: top;
-    }
+  .text {
+    color: #fff;
+    font-size: 16px;
+  }
+}
 
-    .dcontent-2 {
-        padding: 0 40px;
-        background-color: #f3f6f8;
-    }
-    .dcontent-2 .inner-content {
-        background-color: #fff;
-        padding: 16px;
-        height: 100%;
-    }
-    .dcontent-2 .dbreadcrumb {
-        margin-top: 8px;
-    }
-    .dfooter-2 {
-        color: #fff;
-        background-color: #333854;
-        padding: 8px 24px;
-    }
-    
+.dcontent-2 {
+  padding: 0 40px;
+  background-color: #f3f6f8;
+
+  .inner-content {
+    background-color: #fff;
+    padding: 16px;
+    height: 100%;
+  }
+
+  .dbreadcrumb {
+    margin-top: 8px;
+  }
+}
+
+.dfooter-2 {
+  color: #fff;
+  background-color: #333854;
+  padding: 8px 24px;
+}
+
 </style>
 
 ```
@@ -356,7 +347,8 @@ export default defineComponent({
 
 ### Layout
 
-布局容器，可以与`d-header`, `d-content`, `d-footer`, `d-aside`组合实现布局； `d-layout`下可嵌套元素：`d-header`, `d-content`, `d-aside`, `d-layout`。
+布局容器，可以与`d-header`, `d-content`, `d-footer`, `d-aside`组合实现布局； `d-layout`下可嵌套元素：`d-header`
+, `d-content`, `d-aside`, `d-layout`。
 
 ### Header
 


### PR DESCRIPTION
1. 修复 layout 文档示例未正确展示 logo 的bug。
2. 格式化代码风格。
### 修复前
<img width="750" alt="截屏2023-02-06 下午9 34 02" src="https://user-images.githubusercontent.com/52314078/216985023-3521edc9-a268-4ca6-aa45-0d92edaf0655.png">

### 修复后
<img width="820" alt="截屏2023-02-06 下午9 35 02" src="https://user-images.githubusercontent.com/52314078/216985114-a7343089-836f-4b83-ace9-76464e61b1d7.png">
