### PR TITLE
Update image-preview-directive.ts

### DIFF
--- a/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
+++ b/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
@@ -19,7 +19,7 @@ function unmountedPreviewImages() {
 }
 
 function getImgByEl(el: HTMLElement): Array<string> {
-  const urlList = [...el.querySelectorAll('img')].map((item: HTMLImageElement) => item.getAttribute('src'));
+  const urlList = [...el.querySelectorAll('img')].map((item: HTMLImageElement) => item.getAttribute('preview-src') || item.getAttribute('src'));
   return urlList;
 }
 function handleImg(e: MouseEvent) {


### PR DESCRIPTION
fix: 添加预览图片地址， 解决预览图过小问题

可以解决原图片是略缩图的情况， 这样可点击的时候显示需要预览的大图