### PR TITLE
fix: 修改eslint单行太长问题,对ts类型报红完善

### DIFF
--- a/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
+++ b/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
@@ -20,7 +20,7 @@ function unmountedPreviewImages() {
 
 function getImgByEl(el: HTMLElement): Array<string> {
   const imgs = [...el.querySelectorAll('img')];
-  const urlList = [...imgs].map((item: HTMLImageElement) => {
+  const urlList = imgs.map((item: HTMLImageElement) => {
     return (item.getAttribute('preview-src') || item.getAttribute('src')) ?? '';
   });
   return urlList;

--- a/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
+++ b/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
@@ -19,9 +19,13 @@ function unmountedPreviewImages() {
 }
 
 function getImgByEl(el: HTMLElement): Array<string> {
-  const urlList = [...el.querySelectorAll('img')].map((item: HTMLImageElement) => item.getAttribute('preview-src') || item.getAttribute('src'));
+  const imgs = Array.from(el.querySelectorAll('img'));
+  const urlList = [...imgs].map((item: HTMLImageElement) => {
+    return (item.getAttribute('preview-src') || item.getAttribute('src')) ?? '';
+  });
   return urlList;
 }
+
 function handleImg(e: MouseEvent) {
   e.stopPropagation();
   const el = e.currentTarget as PreviewHTMLElement;
@@ -29,6 +33,9 @@ function handleImg(e: MouseEvent) {
   if (target?.nodeName?.toLowerCase() === 'img') {
     const urlList = getImgByEl(el);
     const url = target.getAttribute('src');
+    if (!url) {
+      return console.error('attribute is not exist');
+    }
     mountedPreviewImages({
       url,
       previewUrlList: urlList,
@@ -45,7 +52,7 @@ function removeHandle(el: PreviewHTMLElement) {
 }
 export default {
   mounted(el: PreviewHTMLElement, binding: BindingTypes | undefined): void {
-    if (!binding.value) {
+    if (!binding?.value) {
       return handleImgByEl(el);
     }
     const { custom, disableDefault } = binding.value;
@@ -70,10 +77,10 @@ export default {
     unmountedPreviewImages();
   },
   updated(el: PreviewHTMLElement, binding: UpdateBindingTypes | undefined): void {
-    el.zIndex = binding.value?.zIndex;
-    el.backDropZIndex = binding.value?.backDropZIndex;
+    el.zIndex = binding?.value?.zIndex;
+    el.backDropZIndex = binding?.value?.backDropZIndex;
 
-    if (binding.value) {
+    if (binding?.value) {
       const {
         value: { disableDefault },
         oldValue: { disableDefault: oldDisableDefault },

--- a/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
+++ b/packages/devui-vue/devui/image-preview/src/image-preview-directive.ts
@@ -19,7 +19,7 @@ function unmountedPreviewImages() {
 }
 
 function getImgByEl(el: HTMLElement): Array<string> {
-  const imgs = Array.from(el.querySelectorAll('img'));
+  const imgs = [...el.querySelectorAll('img')];
   const urlList = [...imgs].map((item: HTMLImageElement) => {
     return (item.getAttribute('preview-src') || item.getAttribute('src')) ?? '';
   });

--- a/packages/devui-vue/devui/image-preview/src/image-preview-service.ts
+++ b/packages/devui-vue/devui/image-preview/src/image-preview-service.ts
@@ -10,7 +10,7 @@ class ImagePreviewService {
   static $body: HTMLElement | null = null;
   static $div: HTMLDivElement | null = null;
   // 暂时的禁止滚动穿透,后续应该考虑用modal组件来渲染预览组件
-  static $overflow = '';
+  static $overflow: string | null = '';
 
   static open(props: ImagePreviewProps): void {
     this.$body = document.body;
@@ -25,7 +25,7 @@ class ImagePreviewService {
     this.$body?.style.setProperty('overflow', this.$overflow);
     this.$overflow = null;
 
-    this.$div && this.$body.removeChild(this.$div);
+    this.$div && this.$body?.removeChild(this.$div);
     this.$body = null;
     this.$div = null;
   }

--- a/packages/devui-vue/tsconfig.json
+++ b/packages/devui-vue/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "jsx": "preserve",
     "sourceMap": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext", "dom","DOM.Iterable"],
     "types": ["vite/client", "jest","node"],
     "esModuleInterop": true,
     "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }],


### PR DESCRIPTION
1. 描述： iamge-preview 组件单行太长导致eslint没过构建失败，并修复了ts报红