### PR TITLE
feat(Menu): add `menu` component `router` test case

### DIFF
--- a/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
+++ b/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
@@ -229,8 +229,6 @@ describe('menu test', () => {
   });
 
   it('props router work well.', async () => {
-    const useMenuRouter = ref(false);
-
     const onSelect = jest.fn((e) => {
       return e;
     });
@@ -250,12 +248,11 @@ describe('menu test', () => {
       },
       setup() {
         return {
-          useMenuRouter,
           onSelect,
         };
       },
       template: `
-        <d-menu :router="useMenuRouter" @select="onSelect">
+        <d-menu @select="onSelect">
           <d-menu-item key="/home">首页</d-menu-item>
         </d-menu>
       `,

--- a/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
+++ b/packages/devui-vue/devui/menu/__tests__/menu.spec.ts
@@ -1,5 +1,6 @@
 import { mount, VueWrapper } from '@vue/test-utils';
 import { ComponentPublicInstance, nextTick, ref } from 'vue';
+import { createRouter, createWebHistory } from 'vue-router';
 import { Menu, SubMenu, MenuItem } from '../index';
 import { useNamespace } from '../../shared/hooks/use-namespace';
 
@@ -18,16 +19,21 @@ const menuitemDisabled = ns.b() + '-item-disabled';
 const dotMenuItemSelect = dotNs.b() + '-item-select';
 
 // fix: TypeError: Array.from(...).at is not a function
-!Array.prototype.at && (Array.prototype.at = function at (n) {
-  // Convert the argument to an integer
-  n = Math.trunc(n) || 0; // 去掉小数点
-  // Allow negative indexing from the end
-  if (n < 0) { n += this.length; }
-  // Out-of-bounds access returns undefined
-  if (n < 0 || n >= this.length) { return undefined; }
-  // Otherwise, this is just normal property access
-  return this[n];
-});
+!Array.prototype.at &&
+  (Array.prototype.at = function at(n) {
+    // Convert the argument to an integer
+    n = Math.trunc(n) || 0; // 去掉小数点
+    // Allow negative indexing from the end
+    if (n < 0) {
+      n += this.length;
+    }
+    // Out-of-bounds access returns undefined
+    if (n < 0 || n >= this.length) {
+      return undefined;
+    }
+    // Otherwise, this is just normal property access
+    return this[n];
+  });
 
 describe('menu test', () => {
   let wrapper: VueWrapper<ComponentPublicInstance>;
@@ -152,6 +158,7 @@ describe('menu test', () => {
     expect(wrapper.findAll('i')[0].classes().includes('is-opened')).toBe(true);
     expect(wrapper.findAll('i')[1].classes().includes('is-opened')).toBe(false);
   });
+
   it('props mode(vertical/horizontal) work well.', async () => {
     wrapper = mount({
       components: {
@@ -221,10 +228,68 @@ describe('menu test', () => {
     wrapper.unmount();
   });
 
-  it.todo('props router work well.');
+  it('props router work well.', async () => {
+    const useMenuRouter = ref(false);
+
+    const onSelect = jest.fn((e) => {
+      return e;
+    });
+
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        { path: '/home', name: 'Home', component: { template: '<div>首页</div>' } },
+        { path: '/about', name: 'About', component: { template: '<div>关于</div>' } },
+      ],
+    });
+
+    const component = {
+      components: {
+        'd-menu': Menu,
+        'd-menu-item': MenuItem,
+      },
+      setup() {
+        return {
+          useMenuRouter,
+          onSelect,
+        };
+      },
+      template: `
+        <d-menu :router="useMenuRouter" @select="onSelect">
+          <d-menu-item key="/home">首页</d-menu-item>
+        </d-menu>
+      `,
+    };
+
+    const innerWrapper = mount(component, {
+      global: {
+        plugins: [router],
+      },
+    });
+
+    const firstMenuItem = innerWrapper.find(dotMenuItem);
+    expect(firstMenuItem.exists()).toBe(true);
+
+    await innerWrapper.setProps({
+      router: false,
+    });
+    await firstMenuItem.trigger('click');
+    expect(onSelect).toBeCalledTimes(1);
+    expect(onSelect.mock.results.length).toBe(1);
+    expect(onSelect.mock.results[0].value.hasOwnProperty('route')).toBe(false);
+
+    await innerWrapper.setProps({
+      router: true,
+    });
+    await firstMenuItem.trigger('click');
+    expect(onSelect).toBeCalledTimes(2);
+    expect(onSelect.mock.results.length).toBe(2);
+    expect(onSelect.mock.results[1].value.hasOwnProperty('route')).toBe(true);
+  });
 
   it.todo('slot icon work well.');
-  it('menu - disabled', async ()=>{
+
+  it('menu - disabled', async () => {
     wrapper = wrapper = mount({
       components: {
         'd-menu': Menu,
@@ -232,18 +297,18 @@ describe('menu test', () => {
         'd-menu-item': MenuItem,
       },
       template: `
-      <d-menu>
-        <d-menu-item key="home">首页</d-menu-item>
-        <d-sub-menu title="课程" key="course" class="course" disabled>
-          <d-menu-item key="c"> C </d-menu-item>
-          <d-sub-menu title="Python" key="python">
-            <d-menu-item key="basic"> 基础 </d-menu-item>
-            <d-menu-item key="advanced"> 进阶 </d-menu-item>
+        <d-menu>
+          <d-menu-item key="home">首页</d-menu-item>
+          <d-sub-menu title="课程" key="course" class="course" disabled>
+            <d-menu-item key="c"> C </d-menu-item>
+            <d-sub-menu title="Python" key="python">
+              <d-menu-item key="basic"> 基础 </d-menu-item>
+              <d-menu-item key="advanced"> 进阶 </d-menu-item>
+            </d-sub-menu>
           </d-sub-menu>
-        </d-sub-menu>
-        <d-menu-item key="person">个人</d-menu-item>
-        <d-menu-item key="custom" href="https://www.baidu.com" disabled> Link To Baidu </d-menu-item>
-      </d-menu>
+          <d-menu-item key="person">个人</d-menu-item>
+          <d-menu-item key="custom" href="https://www.baidu.com" disabled> Link To Baidu </d-menu-item>
+        </d-menu>
       `,
     });
     await nextTick();

--- a/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
+++ b/packages/devui-vue/devui/menu/src/components/menu-item/menu-item.tsx
@@ -32,15 +32,15 @@ export default defineComponent({
     const isSelect = ref(initSelect(defaultSelectKey.value, key, multiple, disabled));
     const isLayer1 = ref(true);
     const rootMenuEmit = inject('rootMenuEmit') as (eventName: string, ...args: unknown[]) => void;
-    const useRouter = inject('useRouter') as boolean;
+    const useRouter = inject('useRouter') as Ref<boolean>;
     const router = instance?.appContext.config.globalProperties.$router as Router;
-    const classObject = computed(()=>({
+    const classObject = computed(() => ({
       [`${ns.b()}-item`]: true,
       [`${ns.b()}-item-isCollapsed`]: isCollapsed.value,
       [menuItemSelect]: isSelect.value,
       [menuItemDisabled]: disabled.value,
     }));
-    menuStore.on('menuItem:clear:select', ()=>{
+    menuStore.on('menuItem:clear:select', () => {
       isSelect.value = false;
     });
     const onClick = (e: MouseEvent) => {
@@ -56,7 +56,7 @@ export default defineComponent({
             useClick(e as clickEvent);
           }
           isSelect.value = true;
-          changeRouteResult = changeRoute(props, router, useRouter, key);
+          changeRouteResult = changeRoute(props, router, useRouter.value, key);
         } else {
           if (ele.classList.contains(menuItemSelect)) {
             rootMenuEmit('deselect', { type: 'deselect', key, el: ele, e });
@@ -85,12 +85,12 @@ export default defineComponent({
     const icons = <span class={`${ns.b()}-icon`}>{ctx.slots.icon?.()}</span>;
     const menuItems = ref(null);
     watch(disabled, () => {
-      if (!multiple){
+      if (!multiple) {
         classObject.value[menuItemSelect] = false;
       }
     });
     watch(
-      ()=>[...defaultSelectKey.value],
+      () => [...defaultSelectKey.value],
       (n) => {
         isSelect.value = initSelect(n, key, multiple, disabled);
         classObject.value[menuItemSelect] = isSelect.value;
@@ -132,10 +132,7 @@ export default defineComponent({
     return () => {
       return mode.value === 'vertical' ? (
         <div class={`${ns.b()}-item-vertical-wrapper`}>
-          <li
-            class={classObject.value}
-            onClick={onClick}
-            ref={menuItems}>
+          <li class={classObject.value} onClick={onClick} ref={menuItems}>
             {ctx.slots.icon !== undefined && icons}
             {props.href === '' ? (
               <Transition name="fade">
@@ -149,10 +146,7 @@ export default defineComponent({
           </li>
         </div>
       ) : (
-        <li
-          class={classObject.value}
-          onClick={onClick}
-          ref={menuItems}>
+        <li class={classObject.value} onClick={onClick} ref={menuItems}>
           {ctx.slots.icon !== undefined && icons}
           {props.href === '' ? (
             <Transition name="fade">

--- a/packages/devui-vue/devui/menu/src/components/menu-item/use-menu-item.ts
+++ b/packages/devui-vue/devui/menu/src/components/menu-item/use-menu-item.ts
@@ -45,12 +45,12 @@ export function changeRoute(props: MenuItemProps, router: Router, useRouter: boo
   return undefined;
 }
 
-export function changeSelect(isMultiple: boolean, defaultSelectKeys: string[], key: string): string[]{
-  if (isMultiple){
-    if (!defaultSelectKeys.indexOf(key)){
+export function changeSelect(isMultiple: boolean, defaultSelectKeys: string[], key: string): string[] {
+  if (isMultiple) {
+    if (!defaultSelectKeys.indexOf(key)) {
       defaultSelectKeys.push(key);
     }
-  } else{
+  } else {
     defaultSelectKeys = [];
     defaultSelectKeys.push(key);
   }


### PR DESCRIPTION
1. 添加`menu`组件`router`属性测试用例；
2. `useRouter`使用响应式；
```javascript
const { openKeys, mode, collapsed, defaultSelectKeys } = toRefs(props);
provide('useRouter', props.router);
👇
const { openKeys, mode, collapsed, defaultSelectKeys, router } = toRefs(props);
provide('useRouter', router);
``` 
3. `prettier`代码风格格式化。