### PR TITLE
fix(tree): tree组件新增节点时折叠父节点，父节点会变成懒加载状态

### DIFF
--- a/packages/devui-vue/devui/tree/src/composables/use-operate.ts
+++ b/packages/devui-vue/devui/tree/src/composables/use-operate.ts
@@ -21,6 +21,11 @@ export function useOperate() {
 
       setNodeValue(parentNode, 'expanded', true);
       setNodeValue(parentNode, 'isLeaf', false);
+      let childrenLen = parentNode.childNodeCount;
+      if (!childrenLen) {
+        childrenLen = 0;
+        setNodeValue(parentNode, 'childNodeCount', childrenLen + 1);
+      }
 
       if (lastChild) {
         setNodeValue(lastChild, 'parentChildNodeCount', children.length + 1);


### PR DESCRIPTION
issue #1581 
节点懒加载 [use-lazy-load](https://github.com/DevCloudFE/vue-devui/blob/dev/packages/devui-vue/devui/tree/src/composables/use-lazy-load.ts#L39 ) 通过 isLeaf 和 childNodeCount 来判断，在新增节点时，没有设置新增节点的 childNodeCount 属性，导致折叠父节点 [use-toggle](https://github.com/DevCloudFE/vue-devui/blob/dev/packages/devui-vue/devui/tree/src/composables/use-toggle.ts#L36) 时触发节点懒加载操作。
通过设置新增节点的 childNodeCount 属性，可以防止折叠节点时进入节点懒加载的逻辑。
