### PR TITLE
fix: 使用搜索后有//#刷新页面页面空白的问题 #1619

### DIFF
--- a/packages/devui-vue/docs/.vitepress/devui-theme/components/AlgoliaSearchBox.vue
+++ b/packages/devui-vue/docs/.vitepress/devui-theme/components/AlgoliaSearchBox.vue
@@ -41,16 +41,17 @@ function initialize(userOptions: DefaultTheme.AlgoliaSearchOptions) {
 
     navigator: {
       navigate({ itemUrl }) {
+        const _itemUrl = itemUrl.replaceAll('//', '/');
         const { pathname: hitPathname } = new URL(
-          window.location.origin + itemUrl,
+          window.location.origin + _itemUrl,
         );
-
+        
         // router doesn't handle same-page navigation so we use the native
         // browser location API for anchor navigation
         if (route.path === hitPathname) {
-          window.location.assign(window.location.origin + itemUrl);
+          window.location.assign(window.location.origin + _itemUrl);
         } else {
-          router.go(itemUrl);
+          router.go(_itemUrl);
         }
       },
     },


### PR DESCRIPTION
解决使用搜索时地址栏出现//#xxx后，页面再次刷新会白屏的问题。