### PR TITLE
fix: 文档中md大小按钮高度和实际使用时不同 #1635

### DIFF
--- a/packages/devui-vue/devui/button/src/button.scss
+++ b/packages/devui-vue/devui/button/src/button.scss
@@ -20,6 +20,7 @@ $devui-btn-lg-padding: var(--devui-btn-lg-padding, 0 24px);
 .#{$devui-prefix}-button {
   padding: $devui-btn-padding;
   font-size: $devui-font-size-md;
+  height: $devui-size-md;
   line-height: $devui-line-height-base;
   border-radius: $devui-border-radius;
   border-width: 1px;


### PR DESCRIPTION
文档中的按钮高度和实际使用时不同，文档中有
<img width="480" alt="截屏2023-08-08 17 42 40" src="https://github.com/DevCloudFE/vue-devui/assets/60510247/ab097cb2-41db-49d4-8295-0f2a06ea7d25">
但是实际使用中没有这段代码导致按钮高度缺失