### PR TITLE
fix:  解决InputNumber数字输入框，去除掉值之后失焦/确认之后会变成数值0的问题。

### DIFF
--- a/packages/devui-vue/devui/breadcrumb/src/utils.ts
+++ b/packages/devui-vue/devui/breadcrumb/src/utils.ts
@@ -1,3 +1,3 @@
-export const getPropsSlot = (slots, props, prop = 'default') => {
+export const getPropsSlot = (slots: any, props: any, prop = 'default') => {
   return props[prop] ?? slots[prop]?.();
 };

--- a/packages/devui-vue/devui/category-search/src/components/text-input-menu.tsx
+++ b/packages/devui-vue/devui/category-search/src/components/text-input-menu.tsx
@@ -28,6 +28,7 @@ export default defineComponent({
 					<d-input
 						v-model={formData.text}
 						autocomplete='off'
+						autofocus
 						maxlength={tag.value.maxLength}
 						placeholder={tag.value.placeholder || ''}></d-input>
 				</d-form-item>

--- a/packages/devui-vue/devui/input-number/__tests__/input-number.spec.tsx
+++ b/packages/devui-vue/devui/input-number/__tests__/input-number.spec.tsx
@@ -279,3 +279,20 @@ describe('d-input-number', () => {
     expect(selectFn).toBeCalledTimes(2);
   });
 });
+
+
+it('allowEmpty', async () => {
+  const num = ref();
+  const wrapper = mount({
+    setup() {
+      return () => <DInputNumber v-model={num.value} allowEmpty={true} ></DInputNumber>;
+    },
+  });
+  num.value = undefined;
+  const inputInner = wrapper.find(ns.e('input-box'));
+  expect((inputInner.element as HTMLInputElement).value).toBeNull;
+  num.value = 51;
+  expect((inputInner.element as HTMLInputElement).value).toBe('51');
+  num.value = '';
+  expect((inputInner.element as HTMLInputElement).value).toBeNull;
+});

--- a/packages/devui-vue/devui/input-number/index.ts
+++ b/packages/devui-vue/devui/input-number/index.ts
@@ -8,6 +8,6 @@ export default {
   category: '数据录入',
   status: '50%',
   install(app: App): void {
-    app.component(InputNumber.name, InputNumber);
+    app.component(InputNumber.name as string, InputNumber);
   }
 };

--- a/packages/devui-vue/devui/input-number/src/input-number-types.ts
+++ b/packages/devui-vue/devui/input-number/src/input-number-types.ts
@@ -3,6 +3,9 @@ import type { PropType, ExtractPropTypes, ComputedRef, Ref, CSSProperties, Input
 export type ISize = 'lg' | 'md' | 'sm';
 
 export const inputNumberProps = {
+  modelValue: {
+    type: [Number, String] as PropType<number | string>,
+  },
   placeholder: {
     type: String,
   },
@@ -24,9 +27,6 @@ export const inputNumberProps = {
   },
   size: {
     type: String as PropType<ISize>,
-  },
-  modelValue: {
-    type: Number,
   },
   precision: {
     type: Number,

--- a/packages/devui-vue/devui/input-number/src/input-number-types.ts
+++ b/packages/devui-vue/devui/input-number/src/input-number-types.ts
@@ -4,7 +4,7 @@ export type ISize = 'lg' | 'md' | 'sm';
 
 export const inputNumberProps = {
   modelValue: {
-    type: [Number, String] as PropType<number | string>,
+    type: [Number, String] as PropType<number | string | null | undefined>,
   },
   placeholder: {
     type: String,
@@ -39,13 +39,17 @@ export const inputNumberProps = {
     type: Boolean,
     default: true,
   },
+  allowEmpty: {
+    type: Boolean,
+    default: false,
+  }
 } as const;
 
 export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>;
 
 export interface IState {
-  currentValue: number | string | undefined;
-  userInputValue: number | string | undefined;
+  currentValue: number | string | undefined | null;
+  userInputValue: number | string | undefined | null;
 }
 
 export interface UseExpose {
@@ -62,7 +66,7 @@ export interface UseRender {
 }
 
 export interface UseEvent {
-  inputVal: ComputedRef<number | string | undefined>;
+  inputVal: ComputedRef<number | string | undefined | null>;
   minDisabled: ComputedRef<boolean>;
   maxDisabled: ComputedRef<boolean>;
   onAdd: () => void;

--- a/packages/devui-vue/devui/input-number/src/use-input-number.ts
+++ b/packages/devui-vue/devui/input-number/src/use-input-number.ts
@@ -56,7 +56,7 @@ export function useExpose(ctx: SetupContext): UseExpose {
   return { inputRef };
 }
 
-function getPrecision(pre: number | undefined): number {
+function getPrecision(pre: string | number | undefined): number {
   let precision = 0;
   if (isUndefined(pre)) {
     return precision;
@@ -111,6 +111,9 @@ export function useEvent(props: InputNumberProps, ctx: SetupContext, inputRef: R
   };
 
   const correctValue = (value: number | string | undefined | null) => {
+    if (value === '') { // 空串允许被直接返回 因为用户可能会删除掉值
+      return '';
+    }
     // 校验正则
     const valueStr = value + '';
     if (props.reg && !valueStr.match(new RegExp(props.reg))) {
@@ -141,8 +144,8 @@ export function useEvent(props: InputNumberProps, ctx: SetupContext, inputRef: R
 
     state.userInputValue = undefined;
 
-    // 0 可以被更新
-    if (newVal !== 0 && !newVal) {
+    // 0 和 '' 可以被更新
+    if (newVal !== 0 && newVal !== '' && !newVal) {
       ctx.emit('update:modelValue', oldVal);
       return;
     }

--- a/packages/devui-vue/docs/components/input-number/index.md
+++ b/packages/devui-vue/docs/components/input-number/index.md
@@ -223,6 +223,36 @@ export default defineComponent({
 
 :::
 
+### 允许空值
+
+:::demo 当 `allowEmpty` 为 `true` 的时候允许输入框的值为空，空值返回为 `null`，传入数据不为 `number` 类型且上一次输入没有值的时候都会返回null。
+
+```vue
+<template>
+  <div>
+    <d-input-number v-model="num" :allowEmpty="true" @change="onChange"></d-input-number>
+  </div>
+</template>
+<script>
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  setup(props) {
+    const num = ref(undefined);
+    const onChange = (newVal, oldVal) => {
+      console.log(newVal, oldVal);
+    };
+    return {
+      num,
+      onChange
+    };
+  }
+})
+</script>
+```
+
+:::
+
 ### InputNumber 参数
 
 | 参数名         | 类型              | 默认值        | 说明                 | 跳转 Demo            |
@@ -235,7 +265,8 @@ export default defineComponent({
 | disabled    | `boolean`       | false      | 可选，文本框是否被禁用        | [禁用状态](#禁用状态)      |
 | precision   | `number`        | --         | 可选，数值精度            | [精度](#精度)          |
 | size        | [ISize](#isize) | 'md'       | 可选，文本框尺寸           | [尺寸](#尺寸)          |
-| reg         | `RegExp\| string`    |  --   | 可选，用于限制输入的正则或正则字符串 | [正则限制](#正则限制)|
+| reg         | `RegExp \| string`    |  --   | 可选，用于限制输入的正则或正则字符串 | [正则限制](#正则限制)|
+| allowEmpty	| `boolean \| false`	 |  --   | 可选，是否允许值为空	允许空值 | [允许空值](#允许空值) |
 |show-glow-style|`boolean`|true|可选，是否展示悬浮发光效果||
 
 ### InputNumber 事件


### PR DESCRIPTION
支持inputNumber可以允许输入空串值，即用户删除掉所有值之后有效 对应issues #1843 