### PR TITLE
fix:兼容火狐浏览器无法正确判断元素（DevCloudFE#1883）

### DIFF
--- a/packages/devui-vue/devui/shared/utils/dom.ts
+++ b/packages/devui-vue/devui/shared/utils/dom.ts
@@ -10,6 +10,16 @@ export function isComponent(target: any): target is ComponentPublicInstance {
 }
 
 /**
+ * 兼容火狐浏览器判断是否为元素节点
+ * @param {any} element
+ * @returns {boolean}
+ */
+function judgeFireIsElement (element: Element | ComponentPublicInstance | null) {
+  const str = Object.prototype.toString.call(element);
+  return str.includes('object')&&str.includes('HTML')&&str.includes('Element');
+}
+
+/**
  * 提取 Vue Intance 中的元素，如果本身就是元素，直接返回。
  * @param {any} element
  * @returns {Element | null}
@@ -17,13 +27,13 @@ export function isComponent(target: any): target is ComponentPublicInstance {
 export function getElement(
   element: Element | ComponentPublicInstance | null
 ): Element | null {
-  if (element instanceof Element) {
+  if (element instanceof Element || judgeFireIsElement(element)) {
     return element;
   }
   if (
     element &&
     typeof element === 'object' &&
-    element.$el instanceof Element
+    (element.$el instanceof Element || judgeFireIsElement(element.$el))
   ) {
     return element.$el;
   }


### PR DESCRIPTION
![image](https://github.com/DevCloudFE/vue-devui/assets/49834266/227e0f9e-9162-4a65-98f5-502b4a2bd24c)
解决火狐浏览器在微服务下无法正确判断是否为元素问题