### PR TITLE
fix: 快速提示功能去除掉判断其后为空格时不唤起下拉的限制 #1886

### DIFF
--- a/packages/devui-vue/devui/editor-md/src/composables/use-editor-md.ts
+++ b/packages/devui-vue/devui/editor-md/src/composables/use-editor-md.ts
@@ -195,7 +195,6 @@ export function useEditorMd(props: EditorMdProps, ctx: SetupContext) {
       editorIns.focus();
       hideHint();
     };
-
     handler && handler({ prefix, cursorHint, callback });
   };
 
@@ -236,10 +235,6 @@ export function useEditorMd(props: EditorMdProps, ctx: SetupContext) {
       }
     }
     if (cursorHintStart > -1 && hint[0]) {
-      const spacePosition = value.lastIndexOf(' ', cursor.ch);
-      if (spacePosition > cursorHintStart) {
-        return;
-      }
       /* cursor元素将动态变更，设置settimeout保持其可以获取到值 */
       setTimeout(() => {
         showHint();


### PR DESCRIPTION
![mdfast1](https://github.com/DevCloudFE/vue-devui/assets/29527991/b7f0867b-1e2a-4b5e-986e-04c5ca1c629b)
