### PR TITLE
fix(unittest): make unittest runnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "pnpm --filter vue-devui build",
     "build:lib": "pnpm --filter vue-devui build:lib",
     "build:lib:theme": "pnpm --filter vue-devui build:lib:theme",
-    "test": "pnpm --filter vue-devui tests.test"
+    "test": "pnpm --filter vue-devui test"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/packages/devui-vue/devui/progress/src/progress.tsx
+++ b/packages/devui-vue/devui/progress/src/progress.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, defineComponent, effect, reactive, ref, toRefs, watch } from 'vue';
 import { ProgressProps, progressProps, ISvgData } from './progress-types';
-import { useNamespace, middleNum } from '@devui/shared/utils';
+import { useNamespace, middleNum } from '../../../devui/shared/utils';
 import './progress.scss';
 
 export default defineComponent({


### PR DESCRIPTION
# 修复单元测试无法启动的问题

Related Issue: #947 

## 更新

当前单元测试存在问题，无法正常启动。

- 修复了工作环境中的`pnpm test`入口指令
- 修复了`d-progress`的路径引入导致的解析问题

值得注意，此 PR 仅修复了单元测试本身的问题，由于我们的单元测试长期没有更新，所以大量的测试用例本身存在重大问题，可能需要后期处理。
